### PR TITLE
[FEAT] 게이트 웨이 - 인증 추가

### DIFF
--- a/gateway-service/src/main/java/com/vroomvroom/security/AuthFilter.java
+++ b/gateway-service/src/main/java/com/vroomvroom/security/AuthFilter.java
@@ -1,0 +1,72 @@
+package com.vroomvroom.security;
+
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+
+import com.vroomvroom.util.AuthConst;
+import com.vroomvroom.util.JwtUtil;
+
+import reactor.core.publisher.Mono;
+
+@Component
+public class AuthFilter extends AbstractGatewayFilterFactory<AuthFilter.Config> {
+
+	private final JwtUtil jwtUtil;
+
+	public AuthFilter(JwtUtil jwtUtil) {
+		super(AuthFilter.Config.class);
+		this.jwtUtil = jwtUtil;
+	}
+
+	public static class Config {}
+
+	@Override
+	public GatewayFilter apply(Config config) {
+		return (exchange, chain) -> {
+			ServerHttpRequest request = exchange.getRequest();
+			String token = jwtUtil.resolveToken(request);
+
+			if (token == null || !jwtUtil.tokenValidation(token) || jwtUtil.isExpired(token)) {
+				return onError(exchange);
+			}
+
+			String email = jwtUtil.getEmailFromToken(token);
+			String role = jwtUtil.getRoleFromToken(token);
+			Long userId = jwtUtil.getUserIdFromToken(token);
+
+			ServerHttpRequest mutated = request.mutate()
+				.header(AuthConst.HEADER_USER_ID, String.valueOf(userId))
+				.header(AuthConst.HEADER_USER_EMAIL, email)
+				.header(AuthConst.HEADER_USER_ROLE, role)
+				.build();
+
+			return chain.filter(exchange.mutate().request(mutated).build());
+		};
+	}
+
+	private Mono<Void> onError(ServerWebExchange exchange) {
+		ServerHttpResponse response = exchange.getResponse();
+		response.setStatusCode(HttpStatus.UNAUTHORIZED);
+		response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+
+		String body = String.format(
+			"{\"status\": %d, \"message\": \"%s\"}",
+			HttpStatus.UNAUTHORIZED.value(),
+			"Access 토큰이 유효하지 않습니다."
+		);
+
+		DataBuffer buffer = response.bufferFactory().wrap(body.getBytes(StandardCharsets.UTF_8));
+		return response.writeWith(Mono.just(buffer))
+			.doOnError(error -> DataBufferUtils.release(buffer));
+	}
+}

--- a/gateway-service/src/main/java/com/vroomvroom/security/AuthFilter.java
+++ b/gateway-service/src/main/java/com/vroomvroom/security/AuthFilter.java
@@ -66,7 +66,8 @@ public class AuthFilter extends AbstractGatewayFilterFactory<AuthFilter.Config> 
 		);
 
 		DataBuffer buffer = response.bufferFactory().wrap(body.getBytes(StandardCharsets.UTF_8));
+
 		return response.writeWith(Mono.just(buffer))
-			.doOnError(error -> DataBufferUtils.release(buffer));
+			.doFinally(signal -> DataBufferUtils.release(buffer));
 	}
 }

--- a/gateway-service/src/main/java/com/vroomvroom/security/SecurityConfig.java
+++ b/gateway-service/src/main/java/com/vroomvroom/security/SecurityConfig.java
@@ -18,13 +18,6 @@ public class SecurityConfig {
 			.httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)
 			.formLogin(ServerHttpSecurity.FormLoginSpec::disable)
 			.logout(ServerHttpSecurity.LogoutSpec::disable)
-
-			.authorizeExchange(exchanges -> exchanges
-				.pathMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
-				.pathMatchers("/actuator/health", "/actuator/info").permitAll()
-				.anyExchange().permitAll()
-			)
-
 			.build();
 	}
 }

--- a/gateway-service/src/main/java/com/vroomvroom/security/SecurityConfig.java
+++ b/gateway-service/src/main/java/com/vroomvroom/security/SecurityConfig.java
@@ -1,0 +1,30 @@
+package com.vroomvroom.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@Configuration
+@EnableWebFluxSecurity
+public class SecurityConfig {
+
+	@Bean
+	public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+
+		return http
+			.csrf(ServerHttpSecurity.CsrfSpec::disable)
+			.httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)
+			.formLogin(ServerHttpSecurity.FormLoginSpec::disable)
+			.logout(ServerHttpSecurity.LogoutSpec::disable)
+
+			.authorizeExchange(exchanges -> exchanges
+				.pathMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+				.pathMatchers("/actuator/health", "/actuator/info").permitAll()
+				.anyExchange().permitAll()
+			)
+
+			.build();
+	}
+}

--- a/gateway-service/src/main/java/com/vroomvroom/util/AuthConst.java
+++ b/gateway-service/src/main/java/com/vroomvroom/util/AuthConst.java
@@ -1,0 +1,17 @@
+package com.vroomvroom.util;
+
+public class AuthConst {
+
+	public static final String HEADER_AUTHORIZATION = "Authorization";
+	public static final String HEADER_USER_ID = "X-User-Id";
+	public static final String HEADER_USER_EMAIL = "X-User-Email";
+	public static final String HEADER_USER_ROLE = "X-User-Role";
+
+	public static final String BEARER_PREFIX = "Bearer ";
+
+	public static final String CLAIM_EMAIL = "email";
+	public static final String CLAIM_ROLE = "role";
+	public static final String CLAIM_USER_ID = "userId";
+
+	private AuthConst() {}
+}

--- a/gateway-service/src/main/java/com/vroomvroom/util/JwtUtil.java
+++ b/gateway-service/src/main/java/com/vroomvroom/util/JwtUtil.java
@@ -1,0 +1,77 @@
+package com.vroomvroom.util;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+
+@Component
+public class JwtUtil {
+
+	private final String secret;
+	private JwtParser jwtParser;
+
+	public JwtUtil(@Value("${spring.jwt.secret}") String secret) {
+		this.secret = secret;
+	}
+
+	@PostConstruct
+	public void init() {
+		SecretKey secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+		this.jwtParser = Jwts.parserBuilder().setSigningKey(secretKey).build();
+	}
+
+	public boolean tokenValidation(String token) {
+		try {
+			jwtParser.parseClaimsJws(token);
+			return true;
+		} catch (JwtException | IllegalArgumentException e) {
+			return false;
+		}
+	}
+
+	public boolean isExpired(String token) {
+		try {
+			return getAllClaims(token).getExpiration().before(new Date());
+		} catch (ExpiredJwtException e) {
+			return true;
+		}
+	}
+
+	public String getEmailFromToken(String token) {
+		return getAllClaims(token).get(AuthConst.CLAIM_EMAIL, String.class);
+	}
+
+	public Long getUserIdFromToken(String token) {
+		Number id = getAllClaims(token).get(AuthConst.CLAIM_USER_ID, Number.class);
+		return id != null ? id.longValue() : null;
+	}
+
+	public String getRoleFromToken(String token) {
+		return getAllClaims(token).get(AuthConst.CLAIM_ROLE, String.class);
+	}
+
+	private Claims getAllClaims(String token) {
+		return jwtParser.parseClaimsJws(token).getBody();
+	}
+
+	public String resolveToken(ServerHttpRequest request) {
+		String header = request.getHeaders().getFirst(AuthConst.HEADER_AUTHORIZATION);
+		if (header != null && header.startsWith(AuthConst.BEARER_PREFIX)) {
+			return header.substring(AuthConst.BEARER_PREFIX.length());
+		}
+		return null;
+	}
+}

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -20,19 +20,43 @@ spring:
         locator:
           enabled: true
           lower-case-service-id: true
+
       routes:
+        # 회원가입 / 로그인 (JWT 인증 제외)
+        - id: user-auth-free
+          uri: lb://user-service
+          predicates:
+            - Path=/api/v1/auth/signup, /api/v1/auth/login
+
+        # 유저 서비스 (JWT 인증 필요)
         - id: user-service
           uri: lb://user-service
           predicates:
-            - Path=/api/users/**
+            - Path=/api/v1/users/**
+          filters:
+            - AuthFilter
+            - AuthPermissionFilter
+
+        # 허브 서비스 (JWT 인증 필요)
         - id: hub-service
           uri: lb://hub-service
           predicates:
-            - Path=/api/hubs/**
+            - Path=/api/v1/hubs/**
+          filters:
+            - AuthFilter
+            - AuthPermissionFilter
+
+        # 주문 서비스 (JWT 인증 필요)
         - id: order-service
           uri: lb://order-service
           predicates:
-            - Path=/api/orders/**
+            - Path=/api/v1/orders/**
+          filters:
+            - AuthFilter
+            - AuthPermissionFilter
+
+  jwt:
+    secret: ${JWT_SECRET_KEY}
 
 server:
   port: ${GATEWAY_PORT}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #7 

## 📌 개요

- Gateway에서 JWT 검증 및 사용자 정보 헤더 전달 로직 구현

- 인증 제외 경로(/signup, /login) 분리 처리

- 토큰 검증 실패 시 401 응답 반환

## 🔁 변경 사항

- AuthFilter 추가 및 JWT 검증 로직 구현

- 유효 토큰 시 사용자 정보 헤더(userId, email, role) 추가

- application.yml에 인증 제외 경로(/signup, /login) 설정

## 👀 기타 더 이야기해볼 점

- 각 서비스에서 헤더 기반 인증 정보 활용 방식 논의 필요

- 향후 Redis 기반 블랙리스트나 토큰 만료 처리 확장 검토

[요청 흐름 순서]

1. 클라이언트가 요청을 보냄 → Authorization 헤더에 JWT 포함

2. Gateway의 AuthFilter가 요청 가로채서 토큰 추출

3. 토큰 유효성 검증 및 만료 여부 확인

4. 유효하면 토큰에서 userId, email, role 추출

5. 해당 정보를 헤더에 추가한 뒤 대상 서비스로 라우팅

6. 각 MSA 서비스는 전달받은 헤더로 사용자 식별 후 로직 처리

7. 응답이 Gateway를 통해 클라이언트로 반환

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
