### PR TITLE
[FEAT] 배송담당자 생성 API 구현

### DIFF
--- a/delivery-service/src/main/java/com/vroomvroom/delivery/application/command/CreateManagerCommand.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/application/command/CreateManagerCommand.java
@@ -1,0 +1,14 @@
+package com.vroomvroom.delivery.application.command;
+
+import java.util.UUID;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CreateManagerCommand {
+
+    private final Long userId;
+    private final UUID hubId;
+    private final String type;
+}

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/application/service/DeliveryManagerService.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/application/service/DeliveryManagerService.java
@@ -1,0 +1,9 @@
+package com.vroomvroom.delivery.application.service;
+
+import com.vroomvroom.delivery.application.command.CreateManagerCommand;
+import com.vroomvroom.delivery.presentation.dto.response.CreateManagerRes;
+
+public interface DeliveryManagerService {
+
+    CreateManagerRes createManager(CreateManagerCommand request);
+}

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/application/service/impl/DeliveryManagerServiceImpl.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/application/service/impl/DeliveryManagerServiceImpl.java
@@ -1,0 +1,90 @@
+package com.vroomvroom.delivery.application.service.impl;
+
+import com.vroomvroom.delivery.application.command.CreateManagerCommand;
+import com.vroomvroom.delivery.application.service.DeliveryManagerService;
+import com.vroomvroom.delivery.domain.entity.DeliveryManager;
+import com.vroomvroom.delivery.domain.exception.CustomException;
+import com.vroomvroom.delivery.domain.exception.DeliveryErrorCode;
+import com.vroomvroom.delivery.domain.port.HubClient;
+import com.vroomvroom.delivery.domain.port.UserClient;
+import com.vroomvroom.delivery.domain.repository.DeliveryManagerRepository;
+import com.vroomvroom.delivery.domain.vo.DeliveryManagerSequence;
+import com.vroomvroom.delivery.domain.vo.DeliveryManagerType;
+import com.vroomvroom.delivery.domain.vo.HubId;
+import com.vroomvroom.delivery.presentation.dto.response.CreateManagerRes;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DeliveryManagerServiceImpl implements DeliveryManagerService {
+
+    private final DeliveryManagerRepository deliveryManagerRepository;
+
+    private final HubClient hubClient;
+    private final UserClient userClient;
+
+    @Override
+    @Transactional
+    public CreateManagerRes createManager(
+        CreateManagerCommand request
+    ) {
+        if (deliveryManagerRepository.existsByDeliveryManagerId(request.getUserId())) {
+            throw new CustomException(DeliveryErrorCode.MANAGER_ALREADY_EXISTS);
+        }
+
+        DeliveryManagerType managerType = DeliveryManagerType.valueOf(request.getType());
+        return switch (managerType) {
+            case HUB_MANAGER -> createHubManager(request);
+            case COMPANY_MANAGER -> createCompanyManager(request);
+        };
+    }
+
+    private CreateManagerRes createHubManager(CreateManagerCommand request) {
+        userClient.verifyUserHasRole(request.getUserId(), DeliveryManagerType.HUB_MANAGER);
+
+        Long sequence = deliveryManagerRepository.nextGlobalSequence();
+        if (sequence == null) {
+            throw new CustomException(DeliveryErrorCode.HUB_MANAGER_CAPACITY_FULL);
+        }
+
+        DeliveryManager hubManager = DeliveryManager.createHubManager(
+            request.getUserId(),
+            DeliveryManagerType.HUB_MANAGER,
+            DeliveryManagerSequence.of(sequence)
+        );
+
+        try {
+            return CreateManagerRes.from(deliveryManagerRepository.save(hubManager));
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(DeliveryErrorCode.HUB_MANAGER_CAPACITY_FULL);
+        }
+    }
+
+    private CreateManagerRes createCompanyManager(CreateManagerCommand request) {
+        userClient.verifyUserHasRole(request.getUserId(), DeliveryManagerType.COMPANY_MANAGER);
+        hubClient.verifyExists(request.getHubId());
+
+        Long sequence = deliveryManagerRepository.nextHubSequence(request.getHubId());
+        if (sequence == null) {
+            throw new CustomException(DeliveryErrorCode.COMPANY_MANAGER_CAPACITY_FULL);
+        }
+
+        DeliveryManager companyManager = DeliveryManager.createCompanyManager(
+            request.getUserId(),
+            DeliveryManagerType.COMPANY_MANAGER,
+            HubId.of(request.getHubId()),
+            DeliveryManagerSequence.of(sequence)
+        );
+
+        try {
+            return CreateManagerRes.from(deliveryManagerRepository.save(companyManager));
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(DeliveryErrorCode.COMPANY_MANAGER_CAPACITY_FULL);
+        }
+    }
+}

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/domain/entity/Delivery.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/domain/entity/Delivery.java
@@ -1,14 +1,15 @@
 package com.vroomvroom.delivery.domain.entity;
 
+import com.vroomvroom.common.model.BaseTimeEntity;
 import com.vroomvroom.delivery.domain.vo.ArriveHubId;
 import com.vroomvroom.delivery.domain.vo.DeliveryAddress;
-import com.vroomvroom.delivery.domain.vo.DeliveryManagerId;
 import com.vroomvroom.delivery.domain.vo.DeliveryStatus;
 import com.vroomvroom.delivery.domain.vo.OrderId;
 import com.vroomvroom.delivery.domain.vo.ReceiverId;
 import com.vroomvroom.delivery.domain.vo.ReceiverSlackId;
 import com.vroomvroom.delivery.domain.vo.StartHubId;
 import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -17,32 +18,32 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.domain.AbstractAggregateRoot;
 
 @Entity
 @Table(name = "p_delivery")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Delivery extends AbstractAggregateRoot<Delivery> {
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class Delivery extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(columnDefinition = "BINARY(16)")
     private UUID id;
 
     @Embedded
     @AttributeOverride(name = "id", column = @Column(name = "order_id", nullable = false))
     private OrderId orderId;
-
-    @Embedded
-    @AttributeOverride(name = "id", column = @Column(name = "delivery_manager_id", nullable = false))
-    private DeliveryManagerId deliveryManagerId;
 
     @Embedded
     @AttributeOverride(name = "id", column = @Column(name = "start_hub_id", nullable = false))
@@ -60,6 +61,9 @@ public class Delivery extends AbstractAggregateRoot<Delivery> {
     @AttributeOverride(name = "id", column = @Column(name = "receiver_slack_id", nullable = false))
     private ReceiverSlackId receiverSlackId;
 
+    @OneToMany(mappedBy = "delivery", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DeliveryRoute> deliveryRoutes;
+
     @Column(name = "start_time", nullable = false, columnDefinition = "TIMESTAMP")
     private LocalDateTime startTime;
 
@@ -73,4 +77,23 @@ public class Delivery extends AbstractAggregateRoot<Delivery> {
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
     private DeliveryStatus status;
+
+    public static Delivery create(
+        OrderId orderId,
+        StartHubId startHubId, ArriveHubId arriveHubId,
+        List<DeliveryRoute> deliveryRoutes,
+        DeliveryAddress address,
+        ReceiverId receiverId, ReceiverSlackId receiverSlackId
+    ) {
+        return Delivery.builder()
+            .orderId(orderId)
+            .startHubId(startHubId)
+            .arriveHubId(arriveHubId)
+            .receiverId(receiverId)
+            .receiverSlackId(receiverSlackId)
+            .deliveryRoutes(deliveryRoutes)
+            .deliveryAddress(address)
+            .status(DeliveryStatus.HUB_WAITING)
+            .build();
+    }
 }

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/domain/entity/DeliveryManager.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/domain/entity/DeliveryManager.java
@@ -1,47 +1,77 @@
 package com.vroomvroom.delivery.domain.entity;
 
-import com.vroomvroom.delivery.domain.vo.DeliveryId;
+import com.vroomvroom.common.model.BaseTimeEntity;
+import com.vroomvroom.delivery.domain.vo.DeliveryManagerSequence;
 import com.vroomvroom.delivery.domain.vo.DeliveryManagerType;
-import com.vroomvroom.delivery.domain.vo.DeliverySequence;
 import com.vroomvroom.delivery.domain.vo.HubId;
 import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
-public class DeliveryManager {
+@Table(name = "p_delivery_manager")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class DeliveryManager extends BaseTimeEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long deliveryManagerId;
+    @Column(name = "delivery_manager_id")
+    private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "delivery_route_id", nullable = false)
-    private DeliveryRoute deliveryRoute;
-
-    @Embedded
-    @AttributeOverride(name = "id", column = @Column(name = "delivery_id"))
-    private DeliveryId deliveryId;
-
-    // 소속 허브 id
     @Embedded
     @AttributeOverride(name = "id", column = @Column(name = "hub_id"))
     private HubId hubId;
+
+    @OneToMany(mappedBy = "manager", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RouteManagerAssignment> assignments;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private DeliveryManagerType type;
 
     @Embedded
-    @AttributeOverride(name = "value", column = @Column(name = "sequence", nullable = false))
-    private DeliverySequence sequence;
+    @AttributeOverride(name = "value", column = @Column(name = "sequence"))
+    private DeliveryManagerSequence sequence; // manager sequence : 배송담당자 순번 (각자의 회사에서의 순번)
+
+    public static DeliveryManager createHubManager(
+        Long userId,
+        DeliveryManagerType type,
+        DeliveryManagerSequence sequence
+    ) {
+        return DeliveryManager.builder()
+            .id(userId)
+            .type(type)
+            .hubId(null) // 허브 배송 담당자는 소속 허브가 없으므로 null
+            .sequence(sequence)
+            .build();
+    }
+
+    public static DeliveryManager createCompanyManager(
+        Long userId,
+        DeliveryManagerType type,
+        HubId hubId,
+        DeliveryManagerSequence sequence
+    ) {
+        return DeliveryManager.builder()
+            .id(userId)
+            .type(type)
+            .hubId(hubId)
+            .sequence(sequence)
+            .build();
+    }
 }

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/domain/entity/DeliveryRoute.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/domain/entity/DeliveryRoute.java
@@ -3,10 +3,11 @@ package com.vroomvroom.delivery.domain.entity;
 import com.vroomvroom.common.model.BaseTimeEntity;
 import com.vroomvroom.delivery.domain.vo.ArriveHubId;
 import com.vroomvroom.delivery.domain.vo.DeliveryManagerId;
+import com.vroomvroom.delivery.domain.vo.DeliveryRouteSequence;
 import com.vroomvroom.delivery.domain.vo.DeliveryRouteStatus;
-import com.vroomvroom.delivery.domain.vo.DeliverySequence;
 import com.vroomvroom.delivery.domain.vo.StartHubId;
 import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -18,9 +19,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,16 +33,13 @@ import lombok.NoArgsConstructor;
 @Table(name = "p_delivery_route")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
 public class DeliveryRoute extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(columnDefinition = "BINARY(16)")
     private UUID id;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "delivery_id", nullable = false)
-    private Delivery delivery;
 
     @Embedded
     @AttributeOverride(name = "id", column = @Column(name = "delivery_manager_id", nullable = false))
@@ -51,10 +53,18 @@ public class DeliveryRoute extends BaseTimeEntity {
     @AttributeOverride(name = "id", column = @Column(name = "arrive_hub_id", nullable = false))
     private ArriveHubId arriveHubId;
 
-    private Long expectedDistance;
-    private Long expectedDuration;
-    private Long actualDistance;
-    private Long actualDuration;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "delivery_id", nullable = false)
+    private Delivery delivery;
+
+    @OneToMany(mappedBy = "route", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RouteManagerAssignment> assignments;
+
+    private Long expectedDistance; // 미터(m)
+    private Long expectedDuration; // 초(s)
+
+    private Long actualDistance; // 미터(m)
+    private Long actualDuration; // 초(s)
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
@@ -62,5 +72,18 @@ public class DeliveryRoute extends BaseTimeEntity {
 
     @Embedded
     @AttributeOverride(name = "value", column = @Column(name = "sequence", nullable = false))
-    private DeliverySequence sequence;
+    private DeliveryRouteSequence sequence; // route sequence : 배송 순번
+
+    public static DeliveryRoute create(
+        DeliveryRouteStatus deliveryRouteStatus,
+        DeliveryRouteSequence deliverySequence,
+        StartHubId startHubId, ArriveHubId arriveHubId
+    ) {
+        return DeliveryRoute.builder()
+            .status(deliveryRouteStatus)
+            .sequence(deliverySequence)
+            .startHubId(startHubId)
+            .arriveHubId(arriveHubId)
+            .build();
+    }
 }

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/domain/entity/RouteManagerAssignment.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/domain/entity/RouteManagerAssignment.java
@@ -1,0 +1,29 @@
+package com.vroomvroom.delivery.domain.entity;
+
+import com.vroomvroom.common.model.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_route_manager_assignment")
+public class RouteManagerAssignment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "delivery_route_id", nullable = false)
+    private DeliveryRoute route;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "devliery_manager_id", nullable = false)
+    private DeliveryManager manager; // DeliveryManager 중에서도 타입이 HUB_MANAGER
+}

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/domain/exception/CustomException.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/domain/exception/CustomException.java
@@ -1,0 +1,14 @@
+package com.vroomvroom.delivery.domain.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final DeliveryErrorCode errorCode;
+
+    public CustomException(DeliveryErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/domain/exception/DeliveryErrorCode.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/domain/exception/DeliveryErrorCode.java
@@ -1,0 +1,23 @@
+package com.vroomvroom.delivery.domain.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum DeliveryErrorCode {
+
+    // DeliveryManager
+    INVALID_MANAGER_SEQUENCE(HttpStatus.BAD_REQUEST, "잘못된 배송담당자 순번입니다."),
+    INVALID_MANAGER_TYPE(HttpStatus.BAD_REQUEST, "잘못된 담당자 타입입니다."),
+    MANAGER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 배송매니저입니다."),
+    HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 허브 ID입니다."),
+    HUB_MANAGER_CAPACITY_FULL(HttpStatus.CONFLICT, "허브 매니저 정원이 초과되었습니다."),
+    COMPANY_MANAGER_CAPACITY_FULL(HttpStatus.CONFLICT, "해당 허브의 업체매니저 정원이 초과되었습니다."),
+
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/domain/exception/DeliveryExceptionHandler.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/domain/exception/DeliveryExceptionHandler.java
@@ -1,0 +1,77 @@
+package com.vroomvroom.delivery.domain.exception;
+
+import com.vroomvroom.common.api.ApiResponse;
+import com.vroomvroom.common.exception.CustomException;
+import com.vroomvroom.common.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+@Slf4j
+@RestControllerAdvice
+public class DeliveryExceptionHandler {
+
+    @ExceptionHandler(com.vroomvroom.common.exception.CustomException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleBusinessException(CustomException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        log.warn("[BusinessException] {} (status: {})", errorCode.getMessage(),
+            errorCode.getHttpStatus().value());
+        return ResponseEntity
+            .status(errorCode.getHttpStatus())
+            .body(ApiResponse.fail(errorCode));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValid(
+        MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldError() != null
+            ? e.getBindingResult().getFieldError().getDefaultMessage()
+            : "요청 값이 유효하지 않습니다.";
+        log.warn("[ValidationError] {}", message);
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.fail(message, ErrorCode.VALIDATION_ERROR));
+    }
+
+    @ExceptionHandler(BindException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleBindException(BindException e) {
+        String message = e.getBindingResult().getFieldError() != null
+            ? e.getBindingResult().getFieldError().getDefaultMessage()
+            : "요청 파라미터가 유효하지 않습니다.";
+        log.warn("[BindError] {}", message);
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.fail(message, ErrorCode.VALIDATION_ERROR));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleMethodNotSupported(
+        HttpRequestMethodNotSupportedException e) {
+        log.warn("[METHOD_NOT_ALLOWED]", e);
+        return ResponseEntity
+            .status(HttpStatus.METHOD_NOT_ALLOWED)
+            .body(ApiResponse.fail(ErrorCode.METHOD_NOT_ALLOWED));
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleNotFound(NoResourceFoundException e) {
+        log.warn("[NOT_FOUND]", e);
+        return ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(ApiResponse.fail(ErrorCode.NOT_FOUND));
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("[INTERNAL_SERVER_ERROR] {}", e.getMessage(), e);
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ApiResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/domain/port/HubClient.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/domain/port/HubClient.java
@@ -1,0 +1,18 @@
+package com.vroomvroom.delivery.domain.port;
+
+import com.vroomvroom.delivery.application.dto.GetDeliveryRoutesReq;
+import com.vroomvroom.delivery.infrastructure.external.dto.HubDTO;
+import java.util.List;
+import java.util.UUID;
+
+public interface HubClient {
+
+    /**
+     * 공급/수령 업체 허브의 ID를 전달해 각 배송경로에 대한 허브 출발/도착 ID를 요청하는 메서드
+     *
+     * @return HubDTO : 각 배송경로에 대한 출발/도착 허브ID, 소요시간, 거리를 필드로 가짐.
+     */
+    List<HubDTO> getRoutes(GetDeliveryRoutesReq request);
+
+    void verifyExists(UUID hubId);
+}

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/domain/port/UserClient.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/domain/port/UserClient.java
@@ -1,0 +1,8 @@
+package com.vroomvroom.delivery.domain.port;
+
+import com.vroomvroom.delivery.domain.vo.DeliveryManagerType;
+
+public interface UserClient {
+
+    void verifyUserHasRole(Long userId, DeliveryManagerType deliveryManagerType);
+}

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/domain/repository/DeliveryManagerRepository.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/domain/repository/DeliveryManagerRepository.java
@@ -1,0 +1,16 @@
+package com.vroomvroom.delivery.domain.repository;
+
+import com.vroomvroom.delivery.domain.entity.DeliveryManager;
+import java.util.UUID;
+
+public interface DeliveryManagerRepository {
+
+    DeliveryManager save(DeliveryManager deliveryManager);
+
+    boolean existsByDeliveryManagerId(Long userId);
+
+
+    Long nextGlobalSequence();
+
+    Long nextHubSequence(UUID hubId);
+}

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/domain/vo/DeliveryManagerId.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/domain/vo/DeliveryManagerId.java
@@ -1,7 +1,6 @@
 package com.vroomvroom.delivery.domain.vo;
 
 import jakarta.persistence.Embeddable;
-import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -13,16 +12,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DeliveryManagerId {
 
-    private UUID id;
+    private Long id;
 
-    private DeliveryManagerId(UUID id) {
+    private DeliveryManagerId(Long id) {
         if (id == null) {
             throw new IllegalArgumentException("유효하지 않는 배송담당자ID 입니다.");
         }
         this.id = id;
     }
 
-    public static DeliveryManagerId of(UUID id) {
+    public static DeliveryManagerId of(Long id) {
         return new DeliveryManagerId(id);
     }
 }

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/domain/vo/DeliveryManagerSequence.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/domain/vo/DeliveryManagerSequence.java
@@ -1,0 +1,33 @@
+package com.vroomvroom.delivery.domain.vo;
+
+import com.vroomvroom.delivery.domain.exception.CustomException;
+import com.vroomvroom.delivery.domain.exception.DeliveryErrorCode;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeliveryManagerSequence {
+
+    private Long value;
+
+    private DeliveryManagerSequence(Long value) {
+        if (value == null || value < 0 || value > 9) {
+            throw new CustomException(DeliveryErrorCode.INVALID_MANAGER_SEQUENCE);
+        }
+        this.value = value;
+    }
+
+    public static DeliveryManagerSequence of(Long value) {
+        return new DeliveryManagerSequence(value);
+    }
+
+    public DeliveryManagerSequence next() {
+        return null;
+    }
+}

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/domain/vo/DeliveryManagerType.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/domain/vo/DeliveryManagerType.java
@@ -2,7 +2,7 @@ package com.vroomvroom.delivery.domain.vo;
 
 public enum DeliveryManagerType {
     HUB_MANAGER("허브매니저"),
-    COMPANY_MANGER("업체매니저");
+    COMPANY_MANAGER("업체매니저");
 
     private final String description;
 

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/domain/vo/DeliveryRouteSequence.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/domain/vo/DeliveryRouteSequence.java
@@ -10,22 +10,22 @@ import lombok.NoArgsConstructor;
 @Getter
 @EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class DeliverySequence {
+public class DeliveryRouteSequence {
 
-    private int value;
+    private Long value;
 
-    private DeliverySequence(int value) {
+    private DeliveryRouteSequence(Long value) {
         if (value < 0) {
             throw new IllegalArgumentException("배송 순번은 0번부터 시작됩니다.");
         }
         this.value = value;
     }
 
-    public static DeliverySequence of(int value) {
-        return new DeliverySequence(value);
+    public static DeliveryRouteSequence of(Long value) {
+        return new DeliveryRouteSequence(value);
     }
 
-    public DeliverySequence next() {
-        return new DeliverySequence(this.value + 1);
+    public DeliveryRouteSequence next() {
+        return new DeliveryRouteSequence(this.value + 1);
     }
 }

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/domain/vo/HubId.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/domain/vo/HubId.java
@@ -1,12 +1,22 @@
 package com.vroomvroom.delivery.domain.vo;
 
+import jakarta.persistence.Embeddable;
 import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class HubId {
-    
+
     private UUID id;
+
     private HubId(UUID id) {
-        if(id == null) {
+        if (id == null) {
             throw new IllegalArgumentException("유효하지 않는 허브ID 입니다.");
         }
         this.id = id;

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/infrastructure/external/HubFeignAdapter.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/infrastructure/external/HubFeignAdapter.java
@@ -1,0 +1,30 @@
+package com.vroomvroom.delivery.infrastructure.external;
+
+import com.vroomvroom.delivery.application.dto.GetDeliveryRoutesReq;
+import com.vroomvroom.delivery.domain.exception.CustomException;
+import com.vroomvroom.delivery.domain.exception.DeliveryErrorCode;
+import com.vroomvroom.delivery.domain.port.HubClient;
+import com.vroomvroom.delivery.infrastructure.external.dto.HubDTO;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class HubFeignAdapter implements HubClient {
+
+    private final HubFeignClient hubFeignClient;
+
+    @Override
+    public List<HubDTO> getRoutes(GetDeliveryRoutesReq request) {
+        return hubFeignClient.getRoutes(request);
+    }
+
+    @Override
+    public void verifyExists(UUID hubId) {
+        if (!hubFeignClient.exists(hubId)) {
+            throw new CustomException(DeliveryErrorCode.HUB_NOT_FOUND);
+        }
+    }
+}

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/infrastructure/external/HubFeignClient.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/infrastructure/external/HubFeignClient.java
@@ -1,0 +1,19 @@
+package com.vroomvroom.delivery.infrastructure.external;
+
+import com.vroomvroom.delivery.application.dto.GetDeliveryRoutesReq;
+import com.vroomvroom.delivery.infrastructure.external.dto.HubDTO;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "hub-service")
+public interface HubFeignClient {
+
+    @GetMapping("/api/v1/hubs")
+    List<HubDTO> getRoutes(@RequestBody GetDeliveryRoutesReq request);
+
+    @GetMapping("/api/v1/hubs/{hubId}/exists")
+    boolean exists(UUID hubId);
+}

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/infrastructure/external/UserFeignAdapter.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/infrastructure/external/UserFeignAdapter.java
@@ -1,0 +1,22 @@
+package com.vroomvroom.delivery.infrastructure.external;
+
+import com.vroomvroom.delivery.domain.exception.CustomException;
+import com.vroomvroom.delivery.domain.exception.DeliveryErrorCode;
+import com.vroomvroom.delivery.domain.port.UserClient;
+import com.vroomvroom.delivery.domain.vo.DeliveryManagerType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserFeignAdapter implements UserClient {
+
+    private final UserFeignClient userFeignClient;
+
+    @Override
+    public void verifyUserHasRole(Long userId, DeliveryManagerType deliveryManagerType) {
+        if (!userFeignClient.hasRole(userId, deliveryManagerType.name())) {
+            throw new CustomException(DeliveryErrorCode.INVALID_MANAGER_TYPE);
+        }
+    }
+}

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/infrastructure/external/UserFeignClient.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/infrastructure/external/UserFeignClient.java
@@ -1,0 +1,16 @@
+package com.vroomvroom.delivery.infrastructure.external;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "user-service")
+public interface UserFeignClient {
+
+    @GetMapping("/api/v1/users/{userId}")
+    boolean hasRole(
+        @PathVariable Long userId,
+        @RequestParam("role") String role
+    );
+}

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/infrastructure/external/dto/HubDTO.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/infrastructure/external/dto/HubDTO.java
@@ -1,0 +1,13 @@
+package com.vroomvroom.delivery.infrastructure.external.dto;
+
+import java.util.UUID;
+import lombok.Data;
+
+@Data
+public class HubDTO {
+
+    private UUID startHubId;
+    private UUID arriveHubId;
+    private Long time; // 초(s)
+    private Long distance; // 미터(m)
+}

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/infrastructure/repository/DeliveryManagerRepositoryAdapter.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/infrastructure/repository/DeliveryManagerRepositoryAdapter.java
@@ -1,0 +1,35 @@
+package com.vroomvroom.delivery.infrastructure.repository;
+
+import com.vroomvroom.delivery.domain.entity.DeliveryManager;
+import com.vroomvroom.delivery.domain.repository.DeliveryManagerRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryManagerRepositoryAdapter implements DeliveryManagerRepository {
+
+    private final JpaDeliveryManagerRepository jpaDeliveryManagerRepository;
+
+    @Override
+    public DeliveryManager save(DeliveryManager deliveryManager) {
+        return jpaDeliveryManagerRepository.save(deliveryManager);
+    }
+
+    @Override
+    public boolean existsByDeliveryManagerId(Long userId) {
+        return jpaDeliveryManagerRepository.existsById(userId);
+    }
+
+    @Override
+    public Long nextGlobalSequence() {
+        return jpaDeliveryManagerRepository.nextGlobalSequence();
+    }
+
+    @Override
+    public Long nextHubSequence(UUID hubId) {
+        return jpaDeliveryManagerRepository.nextHubSequence(hubId);
+    }
+
+}

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/infrastructure/repository/JpaDeliveryManagerRepository.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/infrastructure/repository/JpaDeliveryManagerRepository.java
@@ -1,0 +1,42 @@
+package com.vroomvroom.delivery.infrastructure.repository;
+
+import com.vroomvroom.delivery.domain.entity.DeliveryManager;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface JpaDeliveryManagerRepository extends JpaRepository<DeliveryManager, Long> {
+
+    boolean existsById(Long userId);
+
+
+    // 허브 매니저(전역)
+    @Query(value = """
+               SELECT s.seq
+               FROM generate_series(0, 9) AS s(seq)
+               LEFT JOIN p_delivery_manager dm
+                      ON dm.sequence = s.seq
+                     AND dm.type = 'HUB_MANAGER'
+                     AND dm.deleted_at IS NULL
+               WHERE dm.sequence IS NULL
+               ORDER BY s.seq
+               LIMIT 1
+        """, nativeQuery = true)
+    Long nextGlobalSequence();
+
+    // 업체 매니저(허브별)
+    @Query(value = """
+               SELECT s.seq
+               FROM generate_series(0, 9) AS s(seq)
+               LEFT JOIN p_delivery_manager dm
+                      ON dm.sequence = s.seq
+                     AND dm.type = 'COMPANY_MANAGER'
+                     AND dm.hub_id = :hubId
+                     AND dm.deleted_at IS NULL
+               WHERE dm.sequence IS NULL
+               ORDER BY s.seq
+               LIMIT 1
+        """, nativeQuery = true)
+    Long nextHubSequence(@Param("hubId") UUID hubId);
+}

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/presentation/DeliveryController.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/presentation/DeliveryController.java
@@ -1,7 +1,16 @@
 package com.vroomvroom.delivery.presentation;
 
+import com.vroomvroom.common.api.ApiResponse;
+import com.vroomvroom.delivery.application.service.DeliveryManagerService;
+import com.vroomvroom.delivery.application.command.CreateManagerCommand;
+import com.vroomvroom.delivery.presentation.dto.request.CreateManagerReq;
+import com.vroomvroom.delivery.presentation.dto.response.CreateManagerRes;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,5 +19,21 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/deliveries")
 @RequiredArgsConstructor
 public class DeliveryController {
+
+    private final DeliveryManagerService deliveryManagerService;
+
+    @PostMapping("/manager")
+    public ResponseEntity<ApiResponse<CreateManagerRes>> createDeliveryManager(
+        @Valid @RequestBody CreateManagerReq request
+    ) {
+        CreateManagerCommand command = new CreateManagerCommand(
+            request.getUserId(),
+            request.getHubId(),
+            request.getType()
+        );
+        CreateManagerRes response = deliveryManagerService.createManager(command);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
 
 }

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/presentation/dto/request/CreateManagerReq.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/presentation/dto/request/CreateManagerReq.java
@@ -1,0 +1,17 @@
+package com.vroomvroom.delivery.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class CreateManagerReq {
+
+    @NotNull
+    private Long userId;
+
+    private UUID hubId;
+
+    @NotNull
+    private String type;
+}

--- a/delivery-service/src/main/java/com/vroomvroom/delivery/presentation/dto/response/CreateManagerRes.java
+++ b/delivery-service/src/main/java/com/vroomvroom/delivery/presentation/dto/response/CreateManagerRes.java
@@ -1,0 +1,30 @@
+package com.vroomvroom.delivery.presentation.dto.response;
+
+import com.vroomvroom.delivery.domain.entity.DeliveryManager;
+import com.vroomvroom.delivery.domain.vo.DeliveryManagerType;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CreateManagerRes {
+
+    private final Long userId;
+    private final DeliveryManagerType type;
+    private final UUID hubId;
+    private final Long sequence;
+
+    public static CreateManagerRes from(DeliveryManager manager) {
+        UUID hubId =
+            (manager.getType() == DeliveryManagerType.COMPANY_MANAGER && manager.getHubId() != null)
+                ? manager.getHubId().getId() : null;
+
+        return new CreateManagerRes(
+            manager.getId(),
+            manager.getType(),
+            hubId,
+            manager.getSequence().getValue()
+        );
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #15 

## 📌 개요
- 배송담당자를 생성합니다.
    - `HUB_MANAGER` : 특정 허브에 속해있지 않은 담당자.(허브-허브) 전체 10명
        - 전국 허브 매니저 전체 기준으로 배정됨 (sequence 0~9)
        - 슬롯이 비어있을 경우, 새롭게 추가된 담당자는 비어있는 것 중 가장 작은 번호로 배정됨.
    - `COMPANY_MANAGER` : 특정 허브에 소속된 담당자.(허브 - 수령업체) 허브 당 10명씩(sequence 0~9)
        - 해당 허브 소속 매니저들끼리 배정됨 (A sequence 0\~9 / B sequence 0\~9 / ... )
    - 슬롯이 비어있을 경우, 새롭게 추가된 담당자는 비어있는 것 중 가장 작은 번호로 배정됨.

## 🔁 변경 사항

## 📸 스크린샷
- <img width="525" height="240" alt="image" src="https://github.com/user-attachments/assets/5643ceca-7031-4cb1-a4e8-09c0c93fba76" />

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
