### PR TITLE
[FEAT] 주문 취소 및 수정 기능 구현

### DIFF
--- a/order-service/src/main/java/com/vroomvroom/orderservice/application/OrderService.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/application/OrderService.java
@@ -3,6 +3,7 @@ package com.vroomvroom.orderservice.application;
 
 import com.vroomvroom.orderservice.application.command.CancelOrderCommand;
 import com.vroomvroom.orderservice.application.command.CreateOrderCommand;
+import com.vroomvroom.orderservice.application.command.UpdateOrderCommand;
 import com.vroomvroom.orderservice.application.dto.OrderRes;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,5 +19,5 @@ public interface OrderService {
 
     void cancelOrder(CancelOrderCommand orderId);
 
-    OrderRes updateOrder();
+    void updateOrder(UpdateOrderCommand command);
 }

--- a/order-service/src/main/java/com/vroomvroom/orderservice/application/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/application/OrderServiceImpl.java
@@ -4,6 +4,7 @@ import com.vroomvroom.common.exception.CustomException;
 import com.vroomvroom.common.exception.ErrorCode;
 import com.vroomvroom.orderservice.application.command.CancelOrderCommand;
 import com.vroomvroom.orderservice.application.command.CreateOrderCommand;
+import com.vroomvroom.orderservice.application.command.UpdateOrderCommand;
 import com.vroomvroom.orderservice.application.dto.OrderRes;
 import com.vroomvroom.orderservice.application.service.CompanyClient;
 import com.vroomvroom.orderservice.application.service.ProductClient;
@@ -86,7 +87,7 @@ public class OrderServiceImpl implements OrderService {
             return companyClient.getCompanyHubInfo(companyId);
         } catch (FeignException e) {
             // e "업체 정보 조회 실패"
-            throw new RuntimeException(e);
+            throw new RuntimeException(e); // TODO. ErrorCode 관리
         }
     }
 
@@ -97,7 +98,7 @@ public class OrderServiceImpl implements OrderService {
             return productClient.getProductInfo(productId);
         } catch (FeignException e) {
             // e "상품 정보 조회 실패"
-            throw new RuntimeException(e);
+            throw new RuntimeException(e); // TODO. ErrorCode 관리
         }
     }
 
@@ -110,7 +111,7 @@ public class OrderServiceImpl implements OrderService {
 
         } catch (FeignException e) {
             // e "상품 정보 조회 실패"
-            throw new RuntimeException(e);
+            throw new RuntimeException(e); // TODO. ErrorCode 관리
         }
     }
 
@@ -159,12 +160,12 @@ public class OrderServiceImpl implements OrderService {
                 command.userId(), command.orderId());
 
         Order order = orderRepository.findByIdAndDeletedAtIsNull(command.orderId())
-                .orElseThrow(() -> new CustomException(ErrorCode.BAD_REQUEST));
+                .orElseThrow(() -> new CustomException(ErrorCode.BAD_REQUEST)); // TODO. ErrorCode 관리
 
         // 배송 전 주문만 취소 가능
         if (!order.isCancellable()) {
             log.debug("주문 취소 불가 상태 - 주문 상태={}", order.getOrderStatus());
-            throw new CustomException(ErrorCode.VALIDATION_ERROR);
+            throw new CustomException(ErrorCode.VALIDATION_ERROR); // TODO. ErrorCode 관리
         }
 
         order.updateStatus(OrderStatus.CANCELLED);
@@ -177,12 +178,70 @@ public class OrderServiceImpl implements OrderService {
      * 주문 수정
      * 배송 전 주문만 수정 가능
      *
-     * @return 주문 응답 DTO
      */
     @Transactional
     @Override
-    public OrderRes updateOrder() {
-        return null;
+    public void updateOrder(UpdateOrderCommand command) {
+        log.info("주문 수정 시작 - 주문 ID={}", command.orderId());
+
+        // TODO. 유저 ID 유효성 검증 필요
+
+        Order order = orderRepository.findByIdAndDeletedAtIsNull(command.orderId())
+                .orElseThrow(() -> new CustomException(ErrorCode.BAD_REQUEST)); // TODO. ErrorCode 관리
+
+        if (!order.isModifiable()) {
+            log.debug("주문 수정 불가 상태 - 주문 상태={}", order.getOrderStatus());
+            throw new CustomException(ErrorCode.VALIDATION_ERROR); // TODO. ErrorCode 관리
+        }
+
+        Money newTotalPrice = order.getTotalPrice();
+        BigInteger quantityDiff = null;
+
+        // 수량 변경 시 재고 및 금액 재계산
+        if (command.quantity() != null && !command.quantity().equals(order.getQuantity())) {
+            // 상품 정보 조회
+            ProductDTO product = productClient.getProductInfo(order.getProductId());
+
+            // 수량 차이 계산
+            quantityDiff = command.quantity().subtract(order.getQuantity());
+
+            // 재고 확인
+            if (quantityDiff.compareTo(BigInteger.ZERO) > 0) {
+                if (!productClient.decreaseStocks(order.getProductId(), quantityDiff))
+                    throw new CustomException(ErrorCode.VALIDATION_ERROR); // TODO. ErrorCode 관리
+            } else if (quantityDiff.compareTo(BigInteger.ZERO) < 0)
+                productClient.increaseStocks(order.getProductId(), quantityDiff.abs());
+
+            // 총 금액 재계산
+            newTotalPrice = product.getPrice().multiply(command.quantity());
+        }
+
+        // 주문 수정
+        try {
+            order.update(
+                    command.quantity(),
+                    command.deadline(),
+                    command.requestNote(),
+                    newTotalPrice
+            );
+        } catch (Exception e) {
+            // 재고 변동 시 원래 주문 수량으로 원복
+            if (quantityDiff != null)
+                rollbackStock(order.getProductId(), quantityDiff);
+        }
+        log.info("주문 수정 완료 - 주문 ID={}", command.orderId());
+    }
+
+    private void rollbackStock(UUID productId, BigInteger quantityDiff) {
+        try {
+            if (quantityDiff.compareTo(BigInteger.ZERO) > 0) {
+                productClient.increaseStocks(productId, quantityDiff);
+            } else if (quantityDiff.compareTo(BigInteger.ZERO) < 0)
+                productClient.decreaseStocks(productId, quantityDiff.abs());
+
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR); // TODO. ErrorCode 관리
+        }
     }
 
 }

--- a/order-service/src/main/java/com/vroomvroom/orderservice/application/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/application/OrderServiceImpl.java
@@ -155,7 +155,22 @@ public class OrderServiceImpl implements OrderService {
     @Transactional
     @Override
     public void cancelOrder(CancelOrderCommand command) {
-        // 배송
+        log.info("주문 취소 시작 - 유저 ID={}, 주문 ID={}",
+                command.userId(), command.orderId());
+
+        Order order = orderRepository.findByIdAndDeletedAtIsNull(command.orderId())
+                .orElseThrow(() -> new CustomException(ErrorCode.BAD_REQUEST));
+
+        // 배송 전 주문만 취소 가능
+        if (!order.isCancellable()) {
+            log.debug("주문 취소 불가 상태 - 주문 상태={}", order.getOrderStatus());
+            throw new CustomException(ErrorCode.VALIDATION_ERROR);
+        }
+
+        order.updateStatus(OrderStatus.CANCELLED);
+        order.markAsDeleted();
+        orderRepository.save(order);
+        log.info("주문 삭제 성공 - 주문 ID={}", order.getId());
     }
 
     /**

--- a/order-service/src/main/java/com/vroomvroom/orderservice/application/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/application/OrderServiceImpl.java
@@ -22,7 +22,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.math.BigInteger;
 import java.util.UUID;
 
 @Slf4j
@@ -51,7 +50,7 @@ public class OrderServiceImpl implements OrderService {
         CompanyHubDTO receiveCompany = getCompanyHubInfo(command.receiveCompanyId());
 
         // 외부 상품 서비스 호출 및 총 금액 계산
-        ProductDTO product = getProductInfo(command.productId(), command.quantity());
+        ProductDTO product = getProductInfo(command.productId());
         Money totalPrice = product.getPrice().multiply(command.quantity());
 
         // 주문 생성
@@ -92,7 +91,7 @@ public class OrderServiceImpl implements OrderService {
     }
 
     // 상품 정보 가져오기
-    private ProductDTO getProductInfo(UUID productId, BigInteger quantity) {
+    private ProductDTO getProductInfo(UUID productId) {
         // TODO. 상품 서비스 API 호출
         try {
             return productClient.getProductInfo(productId);
@@ -103,7 +102,7 @@ public class OrderServiceImpl implements OrderService {
     }
 
     // 상품 재고 감소
-    private void decreaseStocks(UUID productId, BigInteger quantity) {
+    private void decreaseStocks(UUID productId, Long quantity) {
         // TODO. 상품 재고 감소 로직
         try {
             if (!productClient.decreaseStocks(productId, quantity))
@@ -195,7 +194,7 @@ public class OrderServiceImpl implements OrderService {
         }
 
         Money newTotalPrice = order.getTotalPrice();
-        BigInteger quantityDiff = null;
+        Long quantityDiff = null;
 
         // 수량 변경 시 재고 및 금액 재계산
         if (command.quantity() != null && !command.quantity().equals(order.getQuantity())) {
@@ -203,14 +202,13 @@ public class OrderServiceImpl implements OrderService {
             ProductDTO product = productClient.getProductInfo(order.getProductId());
 
             // 수량 차이 계산
-            quantityDiff = command.quantity().subtract(order.getQuantity());
+            quantityDiff = command.quantity() - order.getQuantity();
 
             // 재고 확인
-            if (quantityDiff.compareTo(BigInteger.ZERO) > 0) {
-                if (!productClient.decreaseStocks(order.getProductId(), quantityDiff))
-                    throw new CustomException(ErrorCode.VALIDATION_ERROR); // TODO. ErrorCode 관리
-            } else if (quantityDiff.compareTo(BigInteger.ZERO) < 0)
-                productClient.increaseStocks(order.getProductId(), quantityDiff.abs());
+            if (quantityDiff > 0) {
+                decreaseStocks(order.getProductId(), quantityDiff);
+            } else if (quantityDiff < 0)
+                productClient.increaseStocks(order.getProductId(), Math.abs(quantityDiff));
 
             // 총 금액 재계산
             newTotalPrice = product.getPrice().multiply(command.quantity());
@@ -232,12 +230,12 @@ public class OrderServiceImpl implements OrderService {
         log.info("주문 수정 완료 - 주문 ID={}", command.orderId());
     }
 
-    private void rollbackStock(UUID productId, BigInteger quantityDiff) {
+    private void rollbackStock(UUID productId, long quantityDiff) {
         try {
-            if (quantityDiff.compareTo(BigInteger.ZERO) > 0) {
+            if (quantityDiff > 0) {
                 productClient.increaseStocks(productId, quantityDiff);
-            } else if (quantityDiff.compareTo(BigInteger.ZERO) < 0)
-                productClient.decreaseStocks(productId, quantityDiff.abs());
+            } else if (quantityDiff < 0)
+                productClient.decreaseStocks(productId, Math.abs(quantityDiff));
 
         } catch (Exception e) {
             throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR); // TODO. ErrorCode 관리

--- a/order-service/src/main/java/com/vroomvroom/orderservice/application/command/CreateOrderCommand.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/application/command/CreateOrderCommand.java
@@ -1,6 +1,5 @@
 package com.vroomvroom.orderservice.application.command;
 
-import java.math.BigInteger;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -8,7 +7,7 @@ public record CreateOrderCommand(
         UUID supplyCompanyId,
         UUID receiveCompanyId,
         UUID productId,
-        BigInteger quantity,
+        Long quantity,
         LocalDateTime deadline,
         String requestNote
 ) {}

--- a/order-service/src/main/java/com/vroomvroom/orderservice/application/command/UpdateOrderCommand.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/application/command/UpdateOrderCommand.java
@@ -1,0 +1,14 @@
+package com.vroomvroom.orderservice.application.command;
+
+import java.math.BigInteger;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record UpdateOrderCommand(
+        UUID userId,
+        UUID orderId,
+        BigInteger quantity,
+        LocalDateTime deadline,
+        String requestNote
+) {
+}

--- a/order-service/src/main/java/com/vroomvroom/orderservice/application/command/UpdateOrderCommand.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/application/command/UpdateOrderCommand.java
@@ -1,13 +1,12 @@
 package com.vroomvroom.orderservice.application.command;
 
-import java.math.BigInteger;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record UpdateOrderCommand(
         UUID userId,
         UUID orderId,
-        BigInteger quantity,
+        Long quantity,
         LocalDateTime deadline,
         String requestNote
 ) {

--- a/order-service/src/main/java/com/vroomvroom/orderservice/application/dto/OrderRes.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/application/dto/OrderRes.java
@@ -25,7 +25,7 @@ public class OrderRes {
     private UUID productId;
     private UUID deliveryId;
     private Money totalPrice;
-    private BigInteger quantity;
+    private Long quantity;
     private LocalDateTime deadline;
     private String requestNote;
     private OrderStatus orderStatus;

--- a/order-service/src/main/java/com/vroomvroom/orderservice/application/service/ProductClient.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/application/service/ProductClient.java
@@ -9,4 +9,6 @@ public interface ProductClient {
     ProductDTO getProductInfo(UUID productId);
 
     boolean decreaseStocks(UUID productId, BigInteger quantity);
+
+    void increaseStocks(UUID productId, BigInteger abs);
 }

--- a/order-service/src/main/java/com/vroomvroom/orderservice/application/service/ProductClient.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/application/service/ProductClient.java
@@ -2,13 +2,12 @@ package com.vroomvroom.orderservice.application.service;
 
 import com.vroomvroom.orderservice.infrastructure.dto.ProductDTO;
 
-import java.math.BigInteger;
 import java.util.UUID;
 
 public interface ProductClient {
     ProductDTO getProductInfo(UUID productId);
 
-    boolean decreaseStocks(UUID productId, BigInteger quantity);
+    boolean decreaseStocks(UUID productId, long quantity);
 
-    void increaseStocks(UUID productId, BigInteger abs);
+    void increaseStocks(UUID productId, long quantity);
 }

--- a/order-service/src/main/java/com/vroomvroom/orderservice/domain/entity/Order.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/domain/entity/Order.java
@@ -90,4 +90,11 @@ public class Order extends BaseTimeEntity {
     public Money calculateTotalPrice() {
         return totalPrice.multiply(quantity.intValue());
     }
+
+    /**
+     * 삭제 가능 여부 확인
+     */
+    public boolean isCancellable() {
+        return orderStatus.isBeforeShipping();
+    }
 }

--- a/order-service/src/main/java/com/vroomvroom/orderservice/domain/entity/Order.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/domain/entity/Order.java
@@ -97,4 +97,35 @@ public class Order extends BaseTimeEntity {
     public boolean isCancellable() {
         return orderStatus.isBeforeShipping();
     }
+
+    /**
+     * 수정 가능 여부 확인
+     */
+    public boolean isModifiable() {
+        return orderStatus.isBeforeShipping();
+    }
+
+    /**
+     * 주문 수정
+     */
+    public void update(BigInteger quantity, LocalDateTime deadline, String requestNote, Money newTotalPrice) {
+        // 수량 변경
+        if (quantity != null && !quantity.equals(this.quantity)) {
+            this.quantity = quantity;
+            this.totalPrice = newTotalPrice;
+        }
+
+        // 납기일 변경
+        if (deadline != null && !deadline.equals(this.deadline)) {
+            this.deadline = deadline;
+        }
+
+        // 요청사항 변경
+        if (requestNote != null && !requestNote.equals(this.requestNote)) {
+            this.requestNote = requestNote;
+        }
+
+        // 주문 상태 PENDING으로 변경
+        updateStatus(OrderStatus.PENDING);
+    }
 }

--- a/order-service/src/main/java/com/vroomvroom/orderservice/domain/entity/Order.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/domain/entity/Order.java
@@ -9,7 +9,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.math.BigInteger;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -48,7 +47,7 @@ public class Order extends BaseTimeEntity {
     private Money totalPrice;
 
     @Column(nullable = false)
-    private BigInteger quantity;
+    private Long quantity;
 
     @Column(nullable = false)
     private LocalDateTime deadline;
@@ -108,7 +107,7 @@ public class Order extends BaseTimeEntity {
     /**
      * 주문 수정
      */
-    public void update(BigInteger quantity, LocalDateTime deadline, String requestNote, Money newTotalPrice) {
+    public void update(Long quantity, LocalDateTime deadline, String requestNote, Money newTotalPrice) {
         // 수량 변경
         if (quantity != null && !quantity.equals(this.quantity)) {
             this.quantity = quantity;

--- a/order-service/src/main/java/com/vroomvroom/orderservice/domain/vo/Money.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/domain/vo/Money.java
@@ -56,8 +56,8 @@ public class Money {
         return new Money(this.amount.multiply(BigDecimal.valueOf(quantity)));
     }
 
-    public Money multiply(BigInteger quantity) {
-        return new Money(this.amount.multiply(new BigDecimal(quantity)));
+    public Money multiply(long quantity) {
+        return new Money(this.amount.multiply(BigDecimal.valueOf(quantity)));
     }
 
     public Money multiply(BigDecimal rate) {

--- a/order-service/src/main/java/com/vroomvroom/orderservice/domain/vo/OrderStatus.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/domain/vo/OrderStatus.java
@@ -4,17 +4,24 @@ import lombok.Getter;
 
 @Getter
 public enum OrderStatus {
-    PENDING("대기중"),
-    CONFIRMED("확인완료"),
-    PROCESSING("처리중"),
-    SHIPPING("배송중"),
-    DELIVERED("배송완료"),
-    CANCELLED("취소됨"),
-    RETURNED("반품됨");
+    PENDING("대기중", 0),
+    CONFIRMED("확인완료", 1),
+    PROCESSING("처리중", 2),
+    SHIPPING("배송중", 3),
+    DELIVERED("배송완료", 4),
+    CANCELLED("취소됨", -1),
+    RETURNED("반품됨", -1);
 
     private final String description;
+    private final int code;
 
-    OrderStatus(String description) {
+    OrderStatus(String description, int code) {
         this.description = description;
+        this.code = code;
+    }
+
+    // 주문 상태가 배송중 미만 상태인지 확인
+    public boolean isBeforeShipping() {
+        return this.code >= PENDING.code && this.code < SHIPPING.code;
     }
 }

--- a/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/dto/ProductDTO.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/dto/ProductDTO.java
@@ -22,5 +22,5 @@ import java.util.UUID;
 public class ProductDTO {
     private UUID productId;
     private Money price;
-    private BigInteger stock;
+    private Long stock;
 }

--- a/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/external/ProductClientImpl.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/external/ProductClientImpl.java
@@ -2,7 +2,6 @@ package com.vroomvroom.orderservice.infrastructure.external;
 
 import com.vroomvroom.orderservice.application.service.ProductClient;
 import com.vroomvroom.orderservice.domain.vo.Money;
-import com.vroomvroom.orderservice.infrastructure.dto.CompanyHubDTO;
 import com.vroomvroom.orderservice.infrastructure.dto.ProductDTO;
 import org.springframework.stereotype.Component;
 
@@ -25,5 +24,10 @@ public class ProductClientImpl implements ProductClient {
     public boolean decreaseStocks(UUID productId, BigInteger quantity) {
         // TODO. FeignClient를 통한 재고 감소 API 호출?
         return true;
+    }
+
+    @Override
+    public void increaseStocks(UUID productId, BigInteger abs) {
+        // TODO. FeignClient를 통한 재고 증가 API 호출?
     }
 }

--- a/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/external/ProductClientImpl.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/external/ProductClientImpl.java
@@ -16,18 +16,18 @@ public class ProductClientImpl implements ProductClient {
         return ProductDTO.builder()
                 .productId(productId)
                 .price(Money.of(10000)) // TODO. 상품 가격 반영 필요
-                .stock(BigInteger.valueOf(10)) // TODO. 상품 재고 반영 필요
+                .stock(10L) // TODO. 상품 재고 반영 필요
                 .build();
     }
 
     @Override
-    public boolean decreaseStocks(UUID productId, BigInteger quantity) {
+    public boolean decreaseStocks(UUID productId, long quantity) {
         // TODO. FeignClient를 통한 재고 감소 API 호출?
         return true;
     }
 
     @Override
-    public void increaseStocks(UUID productId, BigInteger abs) {
+    public void increaseStocks(UUID productId, long quantity) {
         // TODO. FeignClient를 통한 재고 증가 API 호출?
     }
 }

--- a/order-service/src/main/java/com/vroomvroom/orderservice/presentation/OrderController.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/presentation/OrderController.java
@@ -5,9 +5,12 @@ import com.vroomvroom.common.api.PageResponse;
 import com.vroomvroom.orderservice.application.OrderService;
 import com.vroomvroom.orderservice.application.command.CancelOrderCommand;
 import com.vroomvroom.orderservice.application.command.CreateOrderCommand;
+import com.vroomvroom.orderservice.application.command.UpdateOrderCommand;
 import com.vroomvroom.orderservice.application.dto.OrderRes;
 import com.vroomvroom.orderservice.presentation.dto.request.CreateOrderReq;
+import com.vroomvroom.orderservice.presentation.dto.request.UpdateOrderReq;
 import com.vroomvroom.orderservice.presentation.dto.response.CreateOrderRes;
+import com.vroomvroom.orderservice.presentation.dto.response.UpdateOrderRes;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -106,7 +109,7 @@ public class OrderController {
      */
     @DeleteMapping("/{orderId}")
     public ResponseEntity<ApiResponse<String>> cancelOrder(@PathVariable UUID orderId) {
-        log.info("DELETE /api/v1/cancel/{} - 주문 취소", orderId);
+        log.info("DELETE /api/v1/orders/{} - 주문 취소", orderId);
 
         // TODO. 유저 ID 반영 필요
         CancelOrderCommand command = new CancelOrderCommand(UUID.randomUUID(), orderId);
@@ -114,5 +117,34 @@ public class OrderController {
         orderService.cancelOrder(command);
 
         return ResponseEntity.ok(ApiResponse.success("주문 취소 성공"));
+    }
+
+    /**
+     * 주문 취소
+     * <p>
+     * DELETE /api/v1/orders/{orderId}
+     *
+     * @param orderId 주문 ID
+     * @return OK
+     */
+    @PatchMapping("/{orderId}")
+    public ResponseEntity<ApiResponse<UpdateOrderRes>> updateOrder(
+            @PathVariable UUID orderId,
+            @Valid @RequestBody UpdateOrderReq request) {
+        log.info("PATCH /api/v1/orders/{} - 주문 수정", orderId);
+
+        // TODO. 유저 ID 반영 필요
+        UpdateOrderCommand command = new UpdateOrderCommand(
+                UUID.randomUUID(),
+                orderId,
+                request.getQuantity(),
+                request.getDeadline(),
+                request.getRequestNote());
+
+        orderService.updateOrder(command);
+
+        UpdateOrderRes response = new UpdateOrderRes(orderId, "주문이 성공적으로 변경되었습니다.");
+
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/order-service/src/main/java/com/vroomvroom/orderservice/presentation/OrderController.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/presentation/OrderController.java
@@ -3,9 +3,9 @@ package com.vroomvroom.orderservice.presentation;
 import com.vroomvroom.common.api.ApiResponse;
 import com.vroomvroom.common.api.PageResponse;
 import com.vroomvroom.orderservice.application.OrderService;
+import com.vroomvroom.orderservice.application.command.CancelOrderCommand;
 import com.vroomvroom.orderservice.application.command.CreateOrderCommand;
 import com.vroomvroom.orderservice.application.dto.OrderRes;
-import com.vroomvroom.orderservice.domain.vo.Money;
 import com.vroomvroom.orderservice.presentation.dto.request.CreateOrderReq;
 import com.vroomvroom.orderservice.presentation.dto.response.CreateOrderRes;
 import jakarta.validation.Valid;
@@ -39,6 +39,8 @@ public class OrderController {
     public ResponseEntity<ApiResponse<CreateOrderRes>> createOrder(
             @Valid @RequestBody CreateOrderReq request) {
         log.info("POST /api/v1/orders - 주문 생성 요청");
+
+        // TODO. 유저 ID 반영 필요
 
         CreateOrderCommand command = new CreateOrderCommand(
                 request.getSupplyCompanyId(),
@@ -92,5 +94,25 @@ public class OrderController {
         PageResponse<OrderRes> response = PageResponse.fromPage(page);
 
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 주문 취소
+     * <p>
+     * DELETE /api/v1/orders/{orderId}
+     *
+     * @param orderId 주문 ID
+     * @return OK
+     */
+    @DeleteMapping("/{orderId}")
+    public ResponseEntity<ApiResponse<String>> cancelOrder(@PathVariable UUID orderId) {
+        log.info("DELETE /api/v1/cancel/{} - 주문 취소", orderId);
+
+        // TODO. 유저 ID 반영 필요
+        CancelOrderCommand command = new CancelOrderCommand(UUID.randomUUID(), orderId);
+
+        orderService.cancelOrder(command);
+
+        return ResponseEntity.ok(ApiResponse.success("주문 취소 성공"));
     }
 }

--- a/order-service/src/main/java/com/vroomvroom/orderservice/presentation/dto/request/CreateOrderReq.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/presentation/dto/request/CreateOrderReq.java
@@ -9,7 +9,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.math.BigInteger;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -29,7 +28,7 @@ public class CreateOrderReq {
 
     @NotNull(message = "수량은 필수입니다")
     @Min(value = 1, message = "수량은 최소 1개 이상이어야 합니다")
-    private BigInteger quantity;
+    private Long quantity;
 
     @NotNull(message = "납기일은 필수입니다")
     @Future(message = "납기일은 현재 시간 이후여야 합니다")

--- a/order-service/src/main/java/com/vroomvroom/orderservice/presentation/dto/request/UpdateOrderReq.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/presentation/dto/request/UpdateOrderReq.java
@@ -1,0 +1,27 @@
+package com.vroomvroom.orderservice.presentation.dto.request;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigInteger;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateOrderReq {
+    @Min(value = 1, message = "수량은 최소 1개 이상이어야 합니다")
+    private BigInteger quantity;
+
+    @Future(message = "납기일은 현재 시간 이후여야 합니다")
+    private LocalDateTime deadline;
+
+    @Size(max = 500, message = "요청 사항은 최대 500자까지 입력 가능합니다")
+    private String requestNote;
+}

--- a/order-service/src/main/java/com/vroomvroom/orderservice/presentation/dto/request/UpdateOrderReq.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/presentation/dto/request/UpdateOrderReq.java
@@ -8,7 +8,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.math.BigInteger;
 import java.time.LocalDateTime;
 
 @Getter
@@ -17,7 +16,7 @@ import java.time.LocalDateTime;
 @Builder
 public class UpdateOrderReq {
     @Min(value = 1, message = "수량은 최소 1개 이상이어야 합니다")
-    private BigInteger quantity;
+    private Long quantity;
 
     @Future(message = "납기일은 현재 시간 이후여야 합니다")
     private LocalDateTime deadline;

--- a/order-service/src/main/java/com/vroomvroom/orderservice/presentation/dto/response/UpdateOrderRes.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/presentation/dto/response/UpdateOrderRes.java
@@ -1,0 +1,15 @@
+package com.vroomvroom.orderservice.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateOrderRes {
+    UUID orderId;
+    String message;
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #29

## 📌 개요
주문 취소 및 수정 기능을 구현했습니다.

## 🔁 변경 사항

### 주문 취소 기능 (`cancelOrder`)
- **배송 상태 검증**: `isCancellable()` 메서드로 배송 전 주문만 취소 가능하도록 제한
- **주문 상태 변경**: CANCELLED 상태로 변경 후 soft delete 처리
- **DELETE /api/v1/orders/{orderId}** API 구현

### 주문 수정 기능 (`updateOrder`)
- **배송 상태 검증**: `isModifiable()` 메서드로 배송 전 주문만 수정 가능하도록 제한
- **수량 변경 시 재고 처리**:
  - 수량 증가: 추가 수량만큼 재고 감소 (`decreaseStocks`)
  - 수량 감소: 감소한 수량만큼 재고 증가 (`increaseStocks`)
- **금액 자동 재계산**: 수량 변경 시 상품 가격 × 새 수량으로 totalPrice 재계산
- **보상 트랜잭션**: 주문 수정 실패 시 `rollbackStock`으로 재고 원복
- **PATCH /api/v1/orders/{orderId}** API 구현

### 도메인 개선
- **Order 엔티티**:
  - `isCancellable()`: 취소 가능 여부 검증 메서드 추가
  - `isModifiable()`: 수정 가능 여부 검증 메서드 추가
  - `update()`: 수량, 납기일, 요청사항 수정 메서드 추가
- **OrderStatus enum**:
  - `code` 필드 추가 (진행 단계 표현: 0=PENDING, 1=CONFIRMED, 2=PROCESSING, 3=SHIPPING, 4=DELIVERED, -1=CANCELLED/RETURNED)
  - `isBeforeShipping()`: 배송 전 상태인지 확인하는 메서드 추가

### 주문 수량 타입 변경 (BigInteger → Long)
- **수량 필드 타입 통일**: `Order.quantity`, Request/Response DTO의 quantity를 `Long`으로 변경
- **이유**: 재고 수량은 정수이며, BigInteger는 과도한 타입. Long으로 충분하며 계산이 더 간단함

### ProductClient 확장
- `increaseStocks(UUID productId, long quantity)` 메서드 추가
- 주문 수정/취소 시 재고 증가 처리를 위해 필요

### Command 및 Request 추가
- `UpdateOrderCommand`: 주문 수정 요청 Command (userId, orderId, quantity, deadline, requestNote)
- `UpdateOrderReq`: 주문 수정 요청 DTO (validation 포함)
- `UpdateOrderRes`: 주문 수정 응답 DTO

### 기타 개선
- 주문 생성 시 불필요한 `getProductInfo`의 quantity 파라미터 제거
- RuntimeException에 TODO 주석 추가로 추후 CustomException 변환 필요성 명시

## 📸 스크린샷
<details>
  <summary>주문 수정</summary>
<img width="1073" height="663" alt="image" src="https://github.com/user-attachments/assets/6240c3a7-4cef-4b83-9d28-890171cddb3a" />
</details>

<details>
  <summary>주문 취소</summary>
<img width="1064" height="566" alt="image" src="https://github.com/user-attachments/assets/5b4e0ca4-7cf1-4e90-9db2-710eae28c9f7" />
</details>

## 👀 기타 더 이야기해볼 점
민선님이 얘기해주신 OrderServiceImpl에 외부 서비스 호출 관련한 infrastructure의 DTO 객체들(`CompanyHubDTO`, `ProductDTO`)은 추후 리팩토링하도록 하겠습니다.

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.