### PR TITLE
[FEAT] 유저 서비스

### DIFF
--- a/common-lib/src/main/java/com/vroomvroom/common/exception/CommonErrorCode.java
+++ b/common-lib/src/main/java/com/vroomvroom/common/exception/CommonErrorCode.java
@@ -1,0 +1,22 @@
+package com.vroomvroom.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum CommonErrorCode implements ErrorCode {
+
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다."),
+	BAD_REQUEST(HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다."),
+	NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 경로를 찾을 수 없습니다."),
+	VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "Validation Error");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	CommonErrorCode(HttpStatus httpStatus, String message) {
+		this.httpStatus = httpStatus;
+		this.message = message;
+	}
+}

--- a/common-lib/src/main/java/com/vroomvroom/common/exception/ErrorCode.java
+++ b/common-lib/src/main/java/com/vroomvroom/common/exception/ErrorCode.java
@@ -1,30 +1,10 @@
 package com.vroomvroom.common.exception;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-@Getter
-@AllArgsConstructor
-public enum ErrorCode {
+public interface ErrorCode {
 
-	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
-	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다."),
-	BAD_REQUEST(HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다."),
-	NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 경로를 찾을 수 없습니다."),
-	NOT_RESOURCE_OWNER(HttpStatus.FORBIDDEN, "해당 리소스 소유자가 아닙니다."),
+	HttpStatus getHttpStatus();
+	String getMessage();
 
-	// Valid
-	VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "Validation Error"),
-
-	// Auth
-	INVALID_TOKEN(HttpStatus.BAD_REQUEST, "잘못된 토큰 값입니다."),
-	EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, "JWT 토큰이 비어 있습니다."),
-	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "JWT 토큰이 만료되었습니다."),
-	UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 JWT 토큰입니다."),
-
-	;
-
-	private final HttpStatus httpStatus;
-	private final String message;
 }

--- a/common-lib/src/main/java/com/vroomvroom/common/exception/GlobalExceptionHandler.java
+++ b/common-lib/src/main/java/com/vroomvroom/common/exception/GlobalExceptionHandler.java
@@ -1,7 +1,5 @@
 package com.vroomvroom.common.exception;
 
-import com.vroomvroom.common.api.ApiResponse;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
@@ -11,6 +9,10 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+import com.vroomvroom.common.api.ApiResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -18,43 +20,45 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(CustomException.class)
 	protected ResponseEntity<ApiResponse<Void>> handleBusinessException(CustomException e) {
 		ErrorCode errorCode = e.getErrorCode();
-		log.warn("[BusinessException] {} (status: {})", errorCode.getMessage(),
-				 errorCode.getHttpStatus().value());
+		log.warn("[BusinessException] {} (status: {})",
+			errorCode.getMessage(),
+			errorCode.getHttpStatus().value());
+
 		return ResponseEntity
 			.status(errorCode.getHttpStatus())
 			.body(ApiResponse.fail(errorCode));
 	}
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
-	protected ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValid(
-		MethodArgumentNotValidException e) {
+	protected ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
 		String message = e.getBindingResult().getFieldError() != null
-						 ? e.getBindingResult().getFieldError().getDefaultMessage()
-						 : "요청 값이 유효하지 않습니다.";
+			? e.getBindingResult().getFieldError().getDefaultMessage()
+			: "요청 값이 유효하지 않습니다.";
+
 		log.warn("[ValidationError] {}", message);
 		return ResponseEntity
 			.status(HttpStatus.BAD_REQUEST)
-			.body(ApiResponse.fail(message, ErrorCode.VALIDATION_ERROR));
+			.body(ApiResponse.fail(message, CommonErrorCode.VALIDATION_ERROR));
 	}
 
 	@ExceptionHandler(BindException.class)
 	protected ResponseEntity<ApiResponse<Void>> handleBindException(BindException e) {
 		String message = e.getBindingResult().getFieldError() != null
-						 ? e.getBindingResult().getFieldError().getDefaultMessage()
-						 : "요청 파라미터가 유효하지 않습니다.";
+			? e.getBindingResult().getFieldError().getDefaultMessage()
+			: "요청 파라미터가 유효하지 않습니다.";
+
 		log.warn("[BindError] {}", message);
 		return ResponseEntity
 			.status(HttpStatus.BAD_REQUEST)
-			.body(ApiResponse.fail(message, ErrorCode.VALIDATION_ERROR));
+			.body(ApiResponse.fail(message, CommonErrorCode.VALIDATION_ERROR));
 	}
 
 	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-	protected ResponseEntity<ApiResponse<Void>> handleMethodNotSupported(
-		HttpRequestMethodNotSupportedException e) {
+	protected ResponseEntity<ApiResponse<Void>> handleMethodNotSupported(HttpRequestMethodNotSupportedException e) {
 		log.warn("[METHOD_NOT_ALLOWED]", e);
 		return ResponseEntity
 			.status(HttpStatus.METHOD_NOT_ALLOWED)
-			.body(ApiResponse.fail(ErrorCode.METHOD_NOT_ALLOWED));
+			.body(ApiResponse.fail(CommonErrorCode.METHOD_NOT_ALLOWED));
 	}
 
 	@ExceptionHandler(NoResourceFoundException.class)
@@ -62,7 +66,7 @@ public class GlobalExceptionHandler {
 		log.warn("[NOT_FOUND]", e);
 		return ResponseEntity
 			.status(HttpStatus.NOT_FOUND)
-			.body(ApiResponse.fail(ErrorCode.NOT_FOUND));
+			.body(ApiResponse.fail(CommonErrorCode.NOT_FOUND));
 	}
 
 	@ExceptionHandler(Exception.class)
@@ -70,6 +74,6 @@ public class GlobalExceptionHandler {
 		log.error("[INTERNAL_SERVER_ERROR] {}", e.getMessage(), e);
 		return ResponseEntity
 			.status(HttpStatus.INTERNAL_SERVER_ERROR)
-			.body(ApiResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR));
+			.body(ApiResponse.fail(CommonErrorCode.INTERNAL_SERVER_ERROR));
 	}
 }

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -13,7 +13,13 @@ dependencies {
 
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     runtimeOnly 'org.postgresql:postgresql'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'io.lettuce:lettuce-core'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/user-service/src/main/java/com/vroomvroom/user/application/auth/AuthService.java
+++ b/user-service/src/main/java/com/vroomvroom/user/application/auth/AuthService.java
@@ -1,0 +1,23 @@
+package com.vroomvroom.user.application.auth;
+
+import com.vroomvroom.user.domain.entity.User;
+import com.vroomvroom.user.dto.request.LoginReq;
+import com.vroomvroom.user.dto.request.SignupReq;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public interface AuthService {
+
+	// 회원가입 요청 (승인 대기 상태로 저장)
+	User signup(SignupReq req);
+
+	// 로그인 - 승인된 사용자만 가능, JWT 발급
+	void login(LoginReq req, HttpServletResponse response);
+
+	// 로그아웃 - 토큰 삭제 / 블랙리스트 등록
+	void logout(HttpServletResponse response, HttpServletRequest request);
+
+	// 토큰 재발급 (Access, Refresh 모두 재생성)
+	void reissue(HttpServletRequest request, HttpServletResponse response);
+}

--- a/user-service/src/main/java/com/vroomvroom/user/application/auth/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/vroomvroom/user/application/auth/AuthServiceImpl.java
@@ -1,0 +1,59 @@
+package com.vroomvroom.user.application.auth;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.vroomvroom.user.application.token.TokenService;
+import com.vroomvroom.user.domain.entity.User;
+import com.vroomvroom.user.dto.request.LoginReq;
+import com.vroomvroom.user.dto.request.SignupReq;
+import com.vroomvroom.user.infrastructure.repository.UserRepositoryImpl;
+import com.vroomvroom.user.util.UserConst;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthServiceImpl implements AuthService {
+
+	private final UserRepositoryImpl userRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final TokenService tokenService;
+	private final AuthValidation authValidation;
+
+	@Override
+	public User signup(SignupReq req) {
+		authValidation.validateDuplicateEmail(req.getUserEmail());
+		String encodedPassword = passwordEncoder.encode(req.getPassword());
+		return userRepository.save(User.pending(req, encodedPassword));
+	}
+
+	@Override
+	public void login(LoginReq req, HttpServletResponse response) {
+		User user = authValidation.validateLogin(req);
+		tokenService.issueTokens(response, user);
+	}
+
+	@Override
+	public void logout(HttpServletResponse response, HttpServletRequest request) {
+		String accessToken = extractToken(request.getHeader("Authorization"));
+		tokenService.logout(response, accessToken);
+	}
+
+	@Override
+	public void reissue(HttpServletRequest request, HttpServletResponse response) {
+		String refreshToken = authValidation.validateRefreshToken(request);
+		tokenService.rotateTokens(response, refreshToken);
+	}
+
+	private String extractToken(String header) {
+		if (header != null && header.startsWith(UserConst.TOKEN_PREFIX)) {
+			return header.substring(7);
+		}
+		return header;
+	}
+}

--- a/user-service/src/main/java/com/vroomvroom/user/application/auth/AuthValidation.java
+++ b/user-service/src/main/java/com/vroomvroom/user/application/auth/AuthValidation.java
@@ -1,0 +1,52 @@
+package com.vroomvroom.user.application.auth;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import com.vroomvroom.common.exception.CustomException;
+import com.vroomvroom.user.domain.entity.User;
+import com.vroomvroom.user.domain.model.UserStatus;
+import com.vroomvroom.user.dto.request.LoginReq;
+import com.vroomvroom.user.exception.UserErrorCode;
+import com.vroomvroom.user.infrastructure.repository.UserRepositoryImpl;
+import com.vroomvroom.user.util.UserConst;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AuthValidation {
+
+	private final UserRepositoryImpl userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	public void validateDuplicateEmail(String email) {
+		if (userRepository.existsByEmail(email)) {
+			throw new CustomException(UserErrorCode.DUPLICATE_USER);
+		}
+	}
+
+	public User validateLogin(LoginReq req) {
+		User user = userRepository.findByEmail(req.getEmail())
+			.orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+		if (!passwordEncoder.matches(req.getPassword(), user.getPassword())) {
+			throw new CustomException(UserErrorCode.INVALID_STATUS);
+		}
+
+		if (user.getStatus() != UserStatus.APPROVED) {
+			throw new CustomException(UserErrorCode.INVALID_ROLE);
+		}
+
+		return user;
+	}
+
+	public String validateRefreshToken(HttpServletRequest request) {
+		String refreshToken = request.getHeader(UserConst.HEADER_REFRESH_TOKEN);
+		if (refreshToken == null || refreshToken.isBlank()) {
+			throw new CustomException(UserErrorCode.INVALID_STATUS);
+		}
+		return refreshToken;
+	}
+}

--- a/user-service/src/main/java/com/vroomvroom/user/application/token/TokenService.java
+++ b/user-service/src/main/java/com/vroomvroom/user/application/token/TokenService.java
@@ -1,0 +1,96 @@
+package com.vroomvroom.user.application.token;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.vroomvroom.common.exception.CustomException;
+import com.vroomvroom.user.domain.entity.User;
+import com.vroomvroom.user.exception.UserErrorCode;
+import com.vroomvroom.user.infrastructure.repository.UserRepositoryImpl;
+import com.vroomvroom.user.security.JwtProperties;
+import com.vroomvroom.user.security.JwtTokenProvider;
+import com.vroomvroom.user.util.HeaderUtil;
+import com.vroomvroom.user.util.UserConst;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final RedisTemplate<String, String> redisTemplate;
+	private final JwtProperties jwtProperties;
+	private final UserRepositoryImpl userRepository;
+
+	public void issueTokens(HttpServletResponse response, User user) {
+		String accessToken = createAccessToken(user);
+		String refreshToken = createRefreshToken(user);
+
+		storeRefreshToken(user.getEmail(), refreshToken);
+		HeaderUtil.setAuthHeaders(response, accessToken, refreshToken);
+	}
+
+	public void rotateTokens(HttpServletResponse response, String refreshToken) {
+		String email = jwtTokenProvider.getEmail(refreshToken);
+		validateStoredRefreshToken(email, refreshToken);
+
+		User user = userRepository.findByEmail(email)
+			.orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+		String newAccessToken = createAccessToken(user);
+		String newRefreshToken = createRefreshToken(user);
+
+		storeRefreshToken(email, newRefreshToken);
+		HeaderUtil.setAuthHeaders(response, newAccessToken, newRefreshToken);
+	}
+
+	public void logout(HttpServletResponse response, String accessToken) {
+		String email = jwtTokenProvider.getEmail(accessToken);
+		long ttl = jwtTokenProvider.getRemainingExpiration(accessToken);
+
+		addToBlacklist(email, accessToken, ttl);
+		redisTemplate.delete(email);
+
+		HeaderUtil.clearAuthHeaders(response);
+	}
+
+	private String createAccessToken(User user) {
+		return jwtTokenProvider.createAccessToken(user, jwtProperties.getAccessTokenValidity());
+	}
+
+	private String createRefreshToken(User user) {
+		return jwtTokenProvider.createRefreshToken(user, jwtProperties.getRefreshTokenValidity());
+	}
+
+	private void storeRefreshToken(String email, String refreshToken) {
+		redisTemplate.opsForValue().set(
+			email,
+			refreshToken,
+			jwtProperties.getRefreshTokenValidity(),
+			TimeUnit.MILLISECONDS
+		);
+	}
+
+	private void validateStoredRefreshToken(String email, String refreshToken) {
+		String storedToken = redisTemplate.opsForValue().get(email);
+		if (storedToken == null || !storedToken.equals(refreshToken)) {
+			throw new CustomException(UserErrorCode.INVALID_STATUS);
+		}
+	}
+
+	private void addToBlacklist(String email, String accessToken, long ttl) {
+		String blacklistKey = String.format("%s%s:%s",
+			UserConst.REDIS_BLACKLIST_PREFIX, email, accessToken);
+
+		redisTemplate.opsForValue().set(
+			blacklistKey,
+			"true",
+			ttl,
+			TimeUnit.MILLISECONDS
+		);
+	}
+}

--- a/user-service/src/main/java/com/vroomvroom/user/application/user/UserService.java
+++ b/user-service/src/main/java/com/vroomvroom/user/application/user/UserService.java
@@ -1,0 +1,33 @@
+package com.vroomvroom.user.application.user;
+
+import com.vroomvroom.common.api.PageResponse;
+import com.vroomvroom.user.domain.model.Role;
+import com.vroomvroom.user.dto.response.MyInfoRes;
+import com.vroomvroom.user.dto.response.PendingUserRes;
+
+public interface UserService {
+
+	// 사용자 승인 처리 (MASTER, HUB_MANAGER 만 가능)
+	void approveUser(Long userId, Long approverId);
+
+	// 사용자 가입 거절 (MASTER, HUB_MANAGER 만 가능)
+	void rejectUser(Long userId, Long approverId);
+
+	// 역할 부여 및 변경 (MASTER, HUB_MANAGER 만 가능)
+	void assignRole(Long userId, Role newRole, Long approverId);
+
+	// 사용자 비활성화 (관리자 권한 필요)
+	void deactivateUser(Long userId, Long approverId);
+
+	// 가입 요청 목록(PENDING 상태) 조회
+	PageResponse<PendingUserRes> getPendingUsers(int page, int size);
+
+	// 특정 ID 사용자가 존재하는지 여부 반환
+	boolean existsById(Long userId);
+
+	// 특정 역할을 가진 사용자인지 확인
+	boolean hasRole(Long userId, Role role);
+
+	// 사용자 정보 확인
+	MyInfoRes getMyInfo(Long userId);
+}

--- a/user-service/src/main/java/com/vroomvroom/user/application/user/UserServiceImpl.java
+++ b/user-service/src/main/java/com/vroomvroom/user/application/user/UserServiceImpl.java
@@ -1,0 +1,98 @@
+package com.vroomvroom.user.application.user;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.vroomvroom.common.api.PageResponse;
+import com.vroomvroom.common.exception.CustomException;
+import com.vroomvroom.user.domain.entity.User;
+import com.vroomvroom.user.domain.model.Role;
+import com.vroomvroom.user.domain.model.UserStatus;
+import com.vroomvroom.user.dto.response.MyInfoRes;
+import com.vroomvroom.user.dto.response.PendingUserRes;
+import com.vroomvroom.user.exception.UserErrorCode;
+import com.vroomvroom.user.infrastructure.repository.UserRepositoryImpl;
+import com.vroomvroom.user.util.UserConst;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserServiceImpl implements UserService {
+
+	private final UserRepositoryImpl userRepository;
+	private final UserValidation userValidation;
+
+	@Override
+	public void approveUser(Long userId, Long approverId) {
+		UserPair pair = getUsersOrThrow(userId, approverId);
+		userValidation.validateAdminRole(pair.approver);
+		pair.target.approve(pair.approver);
+	}
+
+	@Override
+	public void rejectUser(Long userId, Long approverId) {
+		UserPair pair = getUsersOrThrow(userId, approverId);
+		userValidation.validateAdminRole(pair.approver);
+		pair.target.reject(pair.approver);
+	}
+
+	@Override
+	public void assignRole(Long userId, Role newRole, Long approverId) {
+		UserPair pair = getUsersOrThrow(userId, approverId);
+		userValidation.validateAdminRole(pair.approver);
+		pair.target.assignRole(newRole, pair.approver);
+	}
+
+	@Override
+	public void deactivateUser(Long userId, Long approverId) {
+		UserPair pair = getUsersOrThrow(userId, approverId);
+		userValidation.validateAdminRole(pair.approver);
+		pair.target.deactivate(pair.approver.getName());
+	}
+
+	@Override
+	public PageResponse<PendingUserRes> getPendingUsers(int page, int size) {
+		Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, UserConst.FIELD_CREATED_AT));
+		Page<User> pendingUsers = userRepository.findAllByStatus(UserStatus.PENDING, pageable);
+		Page<PendingUserRes> dtoPage = pendingUsers.map(PendingUserRes::from);
+		return PageResponse.fromPage(dtoPage);
+	}
+
+	@Override
+	public boolean existsById(Long userId) {
+		return userRepository.existsById(userId);
+	}
+
+	@Override
+	public boolean hasRole(Long userId, Role role) {
+		return userRepository.findById(userId)
+			.map(user -> user.getRole() == role)
+			.orElse(false);
+	}
+
+	@Override
+	public MyInfoRes getMyInfo(Long userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+		return MyInfoRes.from(user);
+	}
+
+	private UserPair getUsersOrThrow(Long userId, Long approverId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+		User approver = userRepository.findById(approverId)
+			.orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+		return new UserPair(user, approver);
+	}
+
+	private record UserPair(User target, User approver) {}
+}

--- a/user-service/src/main/java/com/vroomvroom/user/application/user/UserValidation.java
+++ b/user-service/src/main/java/com/vroomvroom/user/application/user/UserValidation.java
@@ -1,0 +1,22 @@
+package com.vroomvroom.user.application.user;
+
+import org.springframework.stereotype.Component;
+
+import com.vroomvroom.common.exception.CustomException;
+import com.vroomvroom.user.domain.entity.User;
+import com.vroomvroom.user.domain.model.Role;
+import com.vroomvroom.user.exception.UserErrorCode;
+
+@Component
+public class UserValidation {
+
+	public void validateAdminRole(User approver) {
+		if (!isAdmin(approver)) {
+			throw new CustomException(UserErrorCode.INVALID_ROLE);
+		}
+	}
+
+	private boolean isAdmin(User user) {
+		return Role.MASTER.equals(user.getRole()) || Role.HUB_MANAGER.equals(user.getRole());
+	}
+}

--- a/user-service/src/main/java/com/vroomvroom/user/domain/entity/User.java
+++ b/user-service/src/main/java/com/vroomvroom/user/domain/entity/User.java
@@ -1,0 +1,110 @@
+package com.vroomvroom.user.domain.entity;
+
+import com.vroomvroom.common.exception.CustomException;
+import com.vroomvroom.common.model.BaseTimeEntity;
+import com.vroomvroom.user.domain.model.Role;
+import com.vroomvroom.user.domain.model.UserStatus;
+import com.vroomvroom.user.domain.vo.CompanyId;
+import com.vroomvroom.user.domain.vo.SlackId;
+import com.vroomvroom.user.dto.request.SignupReq;
+import com.vroomvroom.user.exception.UserErrorCode;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Table(name = "p_user")
+public class User extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "username")
+	private Long id;
+
+	private String name;
+
+	private String email;
+
+	private String password;
+
+	@Embedded
+	private SlackId slackId;
+
+	@Embedded
+	private CompanyId companyId;
+
+	@Enumerated(EnumType.STRING)
+	private Role role;
+
+	@Enumerated(EnumType.STRING)
+	private UserStatus status;
+
+	@Column(name = "is_public")
+	private boolean isPublic;
+
+	private String createdBy;
+
+	private String updatedBy;
+
+	private String deletedBy;
+
+	public static User pending(SignupReq req, String encodedPassword) {
+		return User.builder()
+			.name(req.getName())
+			.email(req.getUserEmail())
+			.password(encodedPassword)
+			.slackId(req.toSlackId())
+			.companyId(req.toCompanyId())
+			.status(UserStatus.PENDING)
+			.role(Role.DELIVERY_MANAGER)
+			.isPublic(false)
+			.build();
+	}
+
+	public void approve(User approver) {
+		validateApproverRole(approver);
+		this.status = UserStatus.APPROVED;
+		this.updatedBy = approver.getName();
+	}
+
+	public void reject(User approver) {
+		validateApproverRole(approver);
+		this.status = UserStatus.REJECTED;
+		this.updatedBy = approver.getName();
+	}
+
+	public void assignRole(Role newRole, User approver) {
+		validateApproverRole(approver);
+		this.role = newRole;
+		this.updatedBy = approver.getName();
+	}
+
+	public void deactivate(String adminName) {
+		this.deletedBy = adminName;
+		markAsDeleted();
+	}
+
+	private void validateApproverRole(User approver) {
+		Role role = approver.getRole();
+
+		if (role != Role.MASTER && role != Role.HUB_MANAGER) {
+			throw new CustomException(UserErrorCode.INVALID_ROLE);
+		}
+	}
+}

--- a/user-service/src/main/java/com/vroomvroom/user/domain/model/Role.java
+++ b/user-service/src/main/java/com/vroomvroom/user/domain/model/Role.java
@@ -1,0 +1,8 @@
+package com.vroomvroom.user.domain.model;
+
+public enum Role {
+	MASTER,          // 마스터 관리자
+	HUB_MANAGER,     // 허브 관리자
+	DELIVERY_MANAGER,// 배송 담당자
+	COMPANY_MANAGER  // 업체 담당자
+}

--- a/user-service/src/main/java/com/vroomvroom/user/domain/model/UserStatus.java
+++ b/user-service/src/main/java/com/vroomvroom/user/domain/model/UserStatus.java
@@ -1,0 +1,7 @@
+package com.vroomvroom.user.domain.model;
+
+public enum UserStatus {
+	PENDING,     // 승인 대기
+	APPROVED,    // 승인 완료
+	REJECTED     // 가입 거절
+}

--- a/user-service/src/main/java/com/vroomvroom/user/domain/vo/CompanyId.java
+++ b/user-service/src/main/java/com/vroomvroom/user/domain/vo/CompanyId.java
@@ -1,0 +1,40 @@
+package com.vroomvroom.user.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class CompanyId {
+
+	@Column(name = "company_id", nullable = false)
+	private String value;
+
+	public CompanyId(String value) {
+		if (value == null || value.isBlank()) {
+			throw new IllegalArgumentException("회사 ID는 필수값입니다.");
+		}
+		this.value = value;
+	}
+
+	@Override
+	public String toString() {
+		return value;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (!(o instanceof CompanyId companyId)) return false;
+		return value.equals(companyId.value);
+	}
+
+	@Override
+	public int hashCode() {
+		return value.hashCode();
+	}
+}

--- a/user-service/src/main/java/com/vroomvroom/user/domain/vo/SlackId.java
+++ b/user-service/src/main/java/com/vroomvroom/user/domain/vo/SlackId.java
@@ -1,0 +1,40 @@
+package com.vroomvroom.user.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class SlackId {
+
+	@Column(name = "slack_id", nullable = false)
+	private String value;
+
+	public SlackId(String value) {
+		if (value == null || value.isBlank()) {
+			throw new IllegalArgumentException("Slack ID는 필수값입니다.");
+		}
+		this.value = value;
+	}
+
+	@Override
+	public String toString() {
+		return value;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (!(o instanceof SlackId slackId)) return false;
+		return value.equals(slackId.value);
+	}
+
+	@Override
+	public int hashCode() {
+		return value.hashCode();
+	}
+}

--- a/user-service/src/main/java/com/vroomvroom/user/dto/request/ApproveUserReq.java
+++ b/user-service/src/main/java/com/vroomvroom/user/dto/request/ApproveUserReq.java
@@ -1,0 +1,15 @@
+package com.vroomvroom.user.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ApproveUserReq {
+
+	@NotNull(message = "승인 대상 사용자 ID는 필수입니다.")
+	private Long userId;
+
+	private boolean approved;
+}

--- a/user-service/src/main/java/com/vroomvroom/user/dto/request/LoginReq.java
+++ b/user-service/src/main/java/com/vroomvroom/user/dto/request/LoginReq.java
@@ -1,0 +1,17 @@
+package com.vroomvroom.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginReq {
+
+	@Email(message = "이메일 형식이 올바르지 않습니다.")
+	private String email;
+
+	@NotBlank(message = "비밀번호는 필수입니다.")
+	private String password;
+}

--- a/user-service/src/main/java/com/vroomvroom/user/dto/request/SignupReq.java
+++ b/user-service/src/main/java/com/vroomvroom/user/dto/request/SignupReq.java
@@ -1,0 +1,43 @@
+package com.vroomvroom.user.dto.request;
+
+import com.vroomvroom.user.domain.vo.CompanyId;
+import com.vroomvroom.user.domain.vo.SlackId;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignupReq {
+
+	@NotBlank(message = "이름은 필수입니다.")
+	private String name;
+
+	@Pattern(
+		regexp = "^[a-z0-9]{4,10}$",
+		message = "아이디는 4~10자의 소문자 알파벳과 숫자만 사용할 수 있습니다."
+	)
+	private String userEmail;
+
+	@Pattern(
+		regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*])[A-Za-z\\d!@#$%^&*]{8,15}$",
+		message = "비밀번호는 8~15자이며, 영문 대소문자, 숫자, 특수문자를 포함해야 합니다."
+	)
+	private String password;
+
+	@NotBlank(message = "Slack ID는 필수입니다.")
+	private String slackId;
+
+	@NotBlank(message = "소속 업체명 또는 허브명은 필수입니다.")
+	private String companyId;
+
+	public SlackId toSlackId() {
+		return new SlackId(slackId);
+	}
+
+	public CompanyId toCompanyId() {
+		return new CompanyId(companyId);
+	}
+}

--- a/user-service/src/main/java/com/vroomvroom/user/dto/response/MyInfoRes.java
+++ b/user-service/src/main/java/com/vroomvroom/user/dto/response/MyInfoRes.java
@@ -1,0 +1,32 @@
+package com.vroomvroom.user.dto.response;
+
+import com.vroomvroom.user.domain.entity.User;
+import com.vroomvroom.user.domain.model.Role;
+import com.vroomvroom.user.domain.model.UserStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MyInfoRes {
+
+	private Long id;
+	private String name;
+	private String email;
+	private Role role;
+	private UserStatus status;
+	private String slackId;
+	private String companyId;
+
+	public static MyInfoRes from(User user) {
+		return MyInfoRes.builder()
+			.id(user.getId())
+			.name(user.getName())
+			.email(user.getEmail())
+			.role(user.getRole())
+			.status(user.getStatus())
+			.slackId(user.getSlackId() != null ? user.getSlackId().getValue() : null)
+			.companyId(user.getCompanyId() != null ? user.getCompanyId().getValue() : null)
+			.build();
+	}
+}

--- a/user-service/src/main/java/com/vroomvroom/user/dto/response/PendingUserRes.java
+++ b/user-service/src/main/java/com/vroomvroom/user/dto/response/PendingUserRes.java
@@ -1,0 +1,31 @@
+package com.vroomvroom.user.dto.response;
+
+import com.vroomvroom.user.domain.entity.User;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class PendingUserRes {
+
+	private final Long id;
+	private final String name;
+	private final String email;
+	private final String slackId;
+	private final String companyId;
+	private final LocalDateTime createdAt;
+
+	public static PendingUserRes from(User user) {
+		return new PendingUserRes(
+			user.getId(),
+			user.getName(),
+			user.getEmail(),
+			user.getSlackId().getValue(),
+			user.getCompanyId().getValue(),
+			user.getCreatedAt()
+		);
+	}
+}

--- a/user-service/src/main/java/com/vroomvroom/user/exception/UserErrorCode.java
+++ b/user-service/src/main/java/com/vroomvroom/user/exception/UserErrorCode.java
@@ -1,0 +1,22 @@
+package com.vroomvroom.user.exception;
+
+import com.vroomvroom.common.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum UserErrorCode implements ErrorCode {
+
+	INVALID_ROLE(HttpStatus.FORBIDDEN, "승인 권한이 없습니다."),
+	INVALID_STATUS(HttpStatus.BAD_REQUEST, "잘못된 사용자 상태입니다."),
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+	DUPLICATE_USER(HttpStatus.CONFLICT, "이미 존재하는 사용자입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	UserErrorCode(HttpStatus httpStatus, String message) {
+		this.httpStatus = httpStatus;
+		this.message = message;
+	}
+}

--- a/user-service/src/main/java/com/vroomvroom/user/infrastructure/config/RedisConfig.java
+++ b/user-service/src/main/java/com/vroomvroom/user/infrastructure/config/RedisConfig.java
@@ -1,0 +1,29 @@
+package com.vroomvroom.user.infrastructure.config;
+
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableConfigurationProperties(RedisProperties.class)
+public class RedisConfig {
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory(RedisProperties redisProperties) {
+		return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+	}
+
+	@Bean
+	public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(connectionFactory);
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		return redisTemplate;
+	}
+}

--- a/user-service/src/main/java/com/vroomvroom/user/infrastructure/repository/JpaUserRepository.java
+++ b/user-service/src/main/java/com/vroomvroom/user/infrastructure/repository/JpaUserRepository.java
@@ -1,0 +1,24 @@
+package com.vroomvroom.user.infrastructure.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.vroomvroom.user.domain.entity.User;
+import com.vroomvroom.user.domain.model.UserStatus;
+
+import lombok.NonNull;
+
+public interface JpaUserRepository extends JpaRepository<User, Long> {
+
+	Optional<User> findByEmail(String email);
+
+	boolean existsByEmail(String email);
+
+	boolean existsById(@NonNull Long id);
+
+	Page<User> findAllByStatus(UserStatus status, Pageable pageable);
+
+}

--- a/user-service/src/main/java/com/vroomvroom/user/infrastructure/repository/UserRepositoryImpl.java
+++ b/user-service/src/main/java/com/vroomvroom/user/infrastructure/repository/UserRepositoryImpl.java
@@ -1,0 +1,51 @@
+package com.vroomvroom.user.infrastructure.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.vroomvroom.user.domain.entity.User;
+import com.vroomvroom.user.domain.model.UserStatus;
+import com.vroomvroom.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+
+	private final JpaUserRepository jpaUserRepository;
+
+	@Override
+	public User save(User user) {
+		return jpaUserRepository.save(user);
+	}
+
+	@Override
+	public Optional<User> findByEmail(String email) {
+		return jpaUserRepository.findByEmail(email);
+	}
+
+	@Override
+	public Optional<User> findById(Long id) {
+		return jpaUserRepository.findById(id);
+	}
+
+	@Override
+	public boolean existsByEmail(String email) {
+		return jpaUserRepository.existsByEmail(email);
+	}
+
+	@Override
+	public boolean existsById(Long id) {
+		return jpaUserRepository.existsById(id);
+	}
+
+	@Override
+	public Page<User> findAllByStatus(UserStatus status, Pageable pageable) {
+		return jpaUserRepository.findAllByStatus(status, pageable);
+	}
+}

--- a/user-service/src/main/java/com/vroomvroom/user/presentation/AuthController.java
+++ b/user-service/src/main/java/com/vroomvroom/user/presentation/AuthController.java
@@ -1,0 +1,47 @@
+package com.vroomvroom.user.presentation;
+
+import com.vroomvroom.common.api.ApiResponse;
+import com.vroomvroom.user.application.auth.AuthService;
+import com.vroomvroom.user.domain.entity.User;
+import com.vroomvroom.user.dto.request.LoginReq;
+import com.vroomvroom.user.dto.request.SignupReq;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+	private final AuthService authService;
+
+	// 회원가입 요청 (승인 대기 상태)
+	@PostMapping("/signup")
+	public ApiResponse<User> signup(@RequestBody SignupReq req) {
+		User user = authService.signup(req);
+		return ApiResponse.success("회원가입 요청이 완료되었습니다. 승인 대기 중입니다.", user);
+	}
+
+	// 로그인
+	@PostMapping("/login")
+	public ApiResponse<Void> login(@RequestBody LoginReq req, HttpServletResponse response) {
+		authService.login(req, response);
+		return ApiResponse.success("로그인 성공", null);
+	}
+
+	// 로그아웃
+	@PostMapping("/logout")
+	public ApiResponse<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+		authService.logout(response, request);
+		return ApiResponse.success("로그아웃 완료", null);
+	}
+
+	// 토큰 재발급
+	@PostMapping("/reissue")
+	public ApiResponse<Void> reissue(HttpServletRequest request, HttpServletResponse response) {
+		authService.reissue(request, response);
+		return ApiResponse.success("토큰이 재발급되었습니다.", null);
+	}
+}

--- a/user-service/src/main/java/com/vroomvroom/user/presentation/UserController.java
+++ b/user-service/src/main/java/com/vroomvroom/user/presentation/UserController.java
@@ -1,0 +1,102 @@
+package com.vroomvroom.user.presentation;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.vroomvroom.common.api.ApiResponse;
+import com.vroomvroom.common.api.PageResponse;
+import com.vroomvroom.user.application.user.UserService;
+import com.vroomvroom.user.domain.model.Role;
+import com.vroomvroom.user.dto.response.MyInfoRes;
+import com.vroomvroom.user.dto.response.PendingUserRes;
+import com.vroomvroom.user.util.UserConst;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+	private final UserService userService;
+
+	// 가입 대기중 사용자 목록 조회
+	@GetMapping("/pending")
+	public ApiResponse<PageResponse<PendingUserRes>> getPendingUsers(
+		@RequestParam(defaultValue = UserConst.DEFAULT_PAGE) int page,
+		@RequestParam(defaultValue = UserConst.DEFAULT_SIZE) int size
+	) {
+		return ApiResponse.success(userService.getPendingUsers(page, size));
+	}
+
+	// 사용자 승인
+	@PostMapping("/{userId}/approve")
+	public ApiResponse<Void> approveUser(
+		@PathVariable Long userId,
+		@RequestHeader(UserConst.HEADER_USER_ID) Long approverId
+	) {
+		userService.approveUser(userId, approverId);
+		return ApiResponse.success("사용자 승인 완료", null);
+	}
+
+	// 사용자 가입 거절
+	@PostMapping("/{userId}/reject")
+	public ApiResponse<Void> rejectUser(
+		@PathVariable Long userId,
+		@RequestHeader(UserConst.HEADER_USER_ID) Long approverId
+	) {
+		userService.rejectUser(userId, approverId);
+		return ApiResponse.success("사용자 가입 거절 완료", null);
+	}
+
+	// 역할 부여 및 변경
+	@PatchMapping("/{userId}/role")
+	public ApiResponse<Void> assignRole(
+		@PathVariable Long userId,
+		@RequestParam Role newRole,
+		@RequestHeader(UserConst.HEADER_USER_ID) Long approverId
+	) {
+		userService.assignRole(userId, newRole, approverId);
+		return ApiResponse.success("역할 변경 완료", null);
+	}
+
+	// 사용자 비활성화
+	@DeleteMapping("/{userId}")
+	public ApiResponse<Void> deactivateUser(
+		@PathVariable Long userId,
+		@RequestHeader(UserConst.HEADER_USER_ID) Long approverId
+	) {
+		userService.deactivateUser(userId, approverId);
+		return ApiResponse.success("사용자 비활성화 완료", null);
+	}
+
+	// 특정 사용자 존재 여부
+	@GetMapping("/{userId}/exists")
+	public ApiResponse<Boolean> existsById(@PathVariable Long userId) {
+		return ApiResponse.success(userService.existsById(userId));
+	}
+
+	// 특정 사용자 역할 확인
+	@GetMapping("/{userId}/role")
+	public ApiResponse<Boolean> hasRole(
+		@PathVariable Long userId,
+		@RequestParam Role role
+	) {
+		return ApiResponse.success(userService.hasRole(userId, role));
+	}
+
+	// 내 정보 조회
+	@GetMapping("/me")
+	public ApiResponse<MyInfoRes> getMyInfo(
+		@RequestHeader(UserConst.HEADER_USER_ID) Long userId
+	) {
+		return ApiResponse.success(userService.getMyInfo(userId));
+	}
+}

--- a/user-service/src/main/java/com/vroomvroom/user/repository/UserRepository.java
+++ b/user-service/src/main/java/com/vroomvroom/user/repository/UserRepository.java
@@ -1,0 +1,25 @@
+package com.vroomvroom.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.vroomvroom.user.domain.entity.User;
+import com.vroomvroom.user.domain.model.UserStatus;
+
+public interface UserRepository {
+
+	User save(User user);
+
+	Optional<User> findByEmail(String email);
+
+	Optional<User> findById(Long id);
+
+	boolean existsByEmail(String email);
+
+	boolean existsById(Long id);
+
+	Page<User> findAllByStatus(UserStatus status, Pageable pageable);
+
+}

--- a/user-service/src/main/java/com/vroomvroom/user/security/JwtProperties.java
+++ b/user-service/src/main/java/com/vroomvroom/user/security/JwtProperties.java
@@ -1,0 +1,18 @@
+package com.vroomvroom.user.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+
+@Getter
+@Component
+public class JwtProperties {
+
+	@Value("${spring.jwt.access-expiration}")
+	private long accessTokenValidity;
+
+	@Value("${spring.jwt.refresh-expiration}")
+	private long refreshTokenValidity;
+
+}

--- a/user-service/src/main/java/com/vroomvroom/user/security/JwtTokenProvider.java
+++ b/user-service/src/main/java/com/vroomvroom/user/security/JwtTokenProvider.java
@@ -1,0 +1,94 @@
+package com.vroomvroom.user.security;
+
+import com.vroomvroom.user.domain.entity.User;
+import com.vroomvroom.user.util.UserConst;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+	@Value("${spring.jwt.secret}")
+	private String secretKey;
+
+	private Key key;
+
+	@PostConstruct
+	public void init() {
+		this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+	}
+
+	public String createAccessToken(User user, long accessTokenValidity) {
+		Date now = new Date();
+		Date expiration = new Date(now.getTime() + accessTokenValidity);
+
+		return Jwts.builder()
+			.setSubject(user.getEmail())
+			.claim(UserConst.CLAIM_USER_ID, user.getId())
+			.claim(UserConst.CLAIM_EMAIL, user.getEmail())
+			.claim(UserConst.CLAIM_ROLE, user.getRole().name())
+			.setIssuedAt(now)
+			.setExpiration(expiration)
+			.signWith(key, SignatureAlgorithm.HS256)
+			.compact();
+	}
+
+	public String createRefreshToken(User user, long refreshTokenValidity) {
+		Date now = new Date();
+		Date expiration = new Date(now.getTime() + refreshTokenValidity);
+
+		return Jwts.builder()
+			.setSubject(user.getEmail())
+			.setIssuedAt(now)
+			.setExpiration(expiration)
+			.signWith(key, SignatureAlgorithm.HS256)
+			.compact();
+	}
+
+	public long getRemainingExpiration(String token) {
+		return Jwts.parserBuilder()
+			.setSigningKey(key)
+			.build()
+			.parseClaimsJws(token)
+			.getBody()
+			.getExpiration()
+			.getTime() - System.currentTimeMillis();
+	}
+
+	public String getEmail(String token) {
+		return Jwts.parserBuilder()
+			.setSigningKey(key)
+			.build()
+			.parseClaimsJws(token)
+			.getBody()
+			.get(UserConst.CLAIM_EMAIL, String.class);
+	}
+
+	public Long getUserId(String token) {
+		return Jwts.parserBuilder()
+			.setSigningKey(key)
+			.build()
+			.parseClaimsJws(token)
+			.getBody()
+			.get(UserConst.CLAIM_USER_ID, Long.class);
+	}
+
+	public String getRole(String token) {
+		return Jwts.parserBuilder()
+			.setSigningKey(key)
+			.build()
+			.parseClaimsJws(token)
+			.getBody()
+			.get(UserConst.CLAIM_ROLE, String.class);
+	}
+}

--- a/user-service/src/main/java/com/vroomvroom/user/util/HeaderUtil.java
+++ b/user-service/src/main/java/com/vroomvroom/user/util/HeaderUtil.java
@@ -1,0 +1,18 @@
+package com.vroomvroom.user.util;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+public class HeaderUtil {
+
+	private HeaderUtil() {}
+
+	public static void setAuthHeaders(HttpServletResponse response, String accessToken, String refreshToken) {
+		response.setHeader(UserConst.HEADER_AUTHORIZATION, UserConst.TOKEN_PREFIX + accessToken);
+		response.setHeader(UserConst.HEADER_REFRESH_TOKEN, refreshToken);
+	}
+
+	public static void clearAuthHeaders(HttpServletResponse response) {
+		response.setHeader(UserConst.HEADER_AUTHORIZATION, "");
+		response.setHeader(UserConst.HEADER_REFRESH_TOKEN, "");
+	}
+}

--- a/user-service/src/main/java/com/vroomvroom/user/util/UserConst.java
+++ b/user-service/src/main/java/com/vroomvroom/user/util/UserConst.java
@@ -1,0 +1,23 @@
+package com.vroomvroom.user.util;
+
+public final class UserConst {
+
+	private UserConst() {}
+
+	public static final String HEADER_AUTHORIZATION = "Authorization";
+	public static final String HEADER_REFRESH_TOKEN = "X-Refresh-Token";
+	public static final String HEADER_USER_ID = "X-User-Id";
+
+	public static final String TOKEN_PREFIX = "Bearer ";
+	public static final String REDIS_BLACKLIST_PREFIX = "blacklist:";
+
+	public static final String CLAIM_USER_ID = "userId";
+	public static final String CLAIM_EMAIL = "email";
+	public static final String CLAIM_ROLE = "role";
+
+	public static final String FIELD_CREATED_AT = "createdAt";
+
+	public static final String DEFAULT_PAGE = "0";
+	public static final String DEFAULT_SIZE = "10";
+
+}

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -27,6 +27,16 @@ spring:
         format_sql: true
         show_sql: true
 
+  jwt:
+    secret: ${JWT_SECRET_KEY}
+    access-expiration: 3600000
+    refresh-expiration: 86400000
+
+  data:
+    redis:
+      host: ${REDIS_HOST:redis}
+      port: ${REDIS_PORT:6379}
+
 eureka:
   client:
     service-url:


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #20 

## 📌 개요

- 사용자 서비스(User Service) 내 인증 및 권한 관리 기능을 완성했습니다.

- 회원가입 요청 시 PENDING 상태로 등록되며, 관리자의 승인 후 로그인 가능하도록 처리했습니다.

- 로그인 시 JWT 발급, Redis 기반 Refresh 토큰 저장 및 Access 토큰 블랙리스트 기능을 추가했습니다.

- 토큰 재발급(로테이팅) 시 기존 Refresh 토큰 검증 후 새 토큰을 재생성하도록 구현했습니다.

- AuthValidation을 분리하여 이메일 중복, 로그인 검증, 토큰 유효성 검사 로직을 서비스로부터 독립시켰습니다.

- UserService를 통해 가입 승인, 거절, 역할 변경, 비활성화 기능을 도메인 규칙에 맞게 처리하도록 구현했습니다.

- common 모듈의 ErrorCode를 인터페이스로 바꾸었습니다.


## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
