### PR TITLE
[FEAT] 주문 서비스 ErrorCode 체계화 및 FeignClient 구조 구현

### DIFF
--- a/order-service/src/main/java/com/vroomvroom/orderservice/OrderServiceApplication.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/OrderServiceApplication.java
@@ -3,10 +3,12 @@ package com.vroomvroom.orderservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @EnableDiscoveryClient
+@EnableFeignClients
 @SpringBootApplication
 public class OrderServiceApplication {
 

--- a/order-service/src/main/java/com/vroomvroom/orderservice/application/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/application/OrderServiceImpl.java
@@ -1,7 +1,6 @@
 package com.vroomvroom.orderservice.application;
 
 import com.vroomvroom.common.exception.CustomException;
-import com.vroomvroom.common.exception.ErrorCode;
 import com.vroomvroom.orderservice.application.command.CancelOrderCommand;
 import com.vroomvroom.orderservice.application.command.CreateOrderCommand;
 import com.vroomvroom.orderservice.application.command.UpdateOrderCommand;
@@ -12,6 +11,7 @@ import com.vroomvroom.orderservice.domain.entity.Order;
 import com.vroomvroom.orderservice.domain.repository.OrderRepository;
 import com.vroomvroom.orderservice.domain.vo.Money;
 import com.vroomvroom.orderservice.domain.vo.OrderStatus;
+import com.vroomvroom.orderservice.exception.OrderErrorCode;
 import com.vroomvroom.orderservice.infrastructure.dto.CompanyHubDTO;
 import com.vroomvroom.orderservice.infrastructure.dto.ProductDTO;
 import feign.FeignException;
@@ -80,11 +80,10 @@ public class OrderServiceImpl implements OrderService {
         // TODO. 상품 재고 감소 로직
         try {
             if (!productClient.decreaseStocks(productId, quantity))
-                throw new RuntimeException("상품 재고 감소 실패");
+                throw new CustomException(OrderErrorCode.PRODUCT_STOCK_DECREASE_FAILED);
 
         } catch (FeignException e) {
-            // e "상품 정보 조회 실패"
-            throw new RuntimeException(e); // TODO. ErrorCode 관리
+            throw new CustomException(OrderErrorCode.PRODUCT_INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -100,7 +99,7 @@ public class OrderServiceImpl implements OrderService {
         log.info("주문 조회 - 주문 ID={}", orderId);
 
         Order order = orderRepository.findByIdAndDeletedAtIsNull(orderId)
-                .orElseThrow(() -> new CustomException(ErrorCode.INTERNAL_SERVER_ERROR)); // TODO. ErrorCode 관리
+                .orElseThrow(() -> new CustomException(OrderErrorCode.ORDER_NOT_FOUND));
 
         return OrderDTO.from(order);
     }
@@ -133,12 +132,12 @@ public class OrderServiceImpl implements OrderService {
                 command.userId(), command.orderId());
 
         Order order = orderRepository.findByIdAndDeletedAtIsNull(command.orderId())
-                .orElseThrow(() -> new CustomException(ErrorCode.BAD_REQUEST)); // TODO. ErrorCode 관리
+                .orElseThrow(() -> new CustomException(OrderErrorCode.ORDER_NOT_FOUND));
 
         // 배송 전 주문만 취소 가능
         if (!order.isCancellable()) {
             log.debug("주문 취소 불가 상태 - 주문 상태={}", order.getOrderStatus());
-            throw new CustomException(ErrorCode.VALIDATION_ERROR); // TODO. ErrorCode 관리
+            throw new CustomException(OrderErrorCode.ORDER_NOT_CANCELLABLE);
         }
 
         order.updateStatus(OrderStatus.CANCELLED);
@@ -161,11 +160,11 @@ public class OrderServiceImpl implements OrderService {
         // TODO. 유저 ID 유효성 검증 필요
 
         Order order = orderRepository.findByIdAndDeletedAtIsNull(command.orderId())
-                .orElseThrow(() -> new CustomException(ErrorCode.BAD_REQUEST)); // TODO. ErrorCode 관리
+                .orElseThrow(() -> new CustomException(OrderErrorCode.ORDER_NOT_FOUND));
 
         if (!order.isModifiable()) {
             log.debug("주문 수정 불가 상태 - 주문 상태={}", order.getOrderStatus());
-            throw new CustomException(ErrorCode.VALIDATION_ERROR); // TODO. ErrorCode 관리
+            throw new CustomException(OrderErrorCode.ORDER_NOT_MODIFIABLE);
         }
 
         Money newTotalPrice = order.getTotalPrice();
@@ -214,7 +213,7 @@ public class OrderServiceImpl implements OrderService {
                 productClient.decreaseStocks(productId, Math.abs(quantityDiff));
 
         } catch (Exception e) {
-            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR); // TODO. ErrorCode 관리
+            throw new CustomException(OrderErrorCode.PRODUCT_INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/order-service/src/main/java/com/vroomvroom/orderservice/application/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/application/OrderServiceImpl.java
@@ -6,6 +6,7 @@ import com.vroomvroom.orderservice.application.command.CreateOrderCommand;
 import com.vroomvroom.orderservice.application.command.UpdateOrderCommand;
 import com.vroomvroom.orderservice.application.dto.OrderDTO;
 import com.vroomvroom.orderservice.application.service.CompanyClient;
+import com.vroomvroom.orderservice.application.service.HubClient;
 import com.vroomvroom.orderservice.application.service.ProductClient;
 import com.vroomvroom.orderservice.domain.entity.Order;
 import com.vroomvroom.orderservice.domain.repository.OrderRepository;
@@ -14,7 +15,7 @@ import com.vroomvroom.orderservice.domain.vo.OrderStatus;
 import com.vroomvroom.orderservice.exception.OrderErrorCode;
 import com.vroomvroom.orderservice.infrastructure.dto.CompanyHubDTO;
 import com.vroomvroom.orderservice.infrastructure.dto.ProductDTO;
-import feign.FeignException;
+import com.vroomvroom.orderservice.infrastructure.dto.StockDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -32,6 +33,7 @@ public class OrderServiceImpl implements OrderService {
     private final OrderRepository orderRepository;
     private final ProductClient productClient;
     private final CompanyClient companyClient;
+    private final HubClient hubClient;
 
     /**
      * 주문 생성
@@ -49,6 +51,10 @@ public class OrderServiceImpl implements OrderService {
         CompanyHubDTO supplyCompany = companyClient.getCompanyHubInfo(command.supplyCompanyId());
         CompanyHubDTO receiveCompany = companyClient.getCompanyHubInfo(command.receiveCompanyId());
         ProductDTO product = productClient.getProductInfo(command.productId());
+        StockDTO stock = hubClient.getStockInfo(supplyCompany.getHubId(), product.getProductId());
+
+        if (stock.getQuantity() <= 0)
+            throw new CustomException(OrderErrorCode.HUB_PRODUCT_OUT_OF_STOCK);
 
         // 주문 생성
         Order order = Order.create(
@@ -64,27 +70,24 @@ public class OrderServiceImpl implements OrderService {
         );
 
         // 재고 차감
-        decreaseStocks(order.getProductId(), order.getQuantity());
+        hubClient.decreaseStocks(order.getProductId(), order.getQuantity());
 
-        // 주문 저장
-        Order savedOrder = orderRepository.save(order);
-
-        // TODO. 주문 저장 실패 시 재고 원복 로직 필요
-
-        log.info("주문 생성 성공 - 주문 ID={}", savedOrder.getId());
-        return OrderDTO.from(savedOrder);
-    }
-
-    // 상품 재고 감소
-    private void decreaseStocks(UUID productId, Long quantity) {
-        // TODO. 상품 재고 감소 로직
+        Order savedOrder = null;
         try {
-            if (!productClient.decreaseStocks(productId, quantity))
-                throw new CustomException(OrderErrorCode.PRODUCT_STOCK_DECREASE_FAILED);
+            // 주문 저장
+            savedOrder = orderRepository.save(order);
 
-        } catch (FeignException e) {
-            throw new CustomException(OrderErrorCode.PRODUCT_INTERNAL_SERVER_ERROR);
+            if (savedOrder == null)
+                hubClient.decreaseStocks(order.getProductId(), order.getQuantity());
+
+            log.info("주문 생성 성공 - 주문 ID={}", savedOrder.getId());
+            return OrderDTO.from(savedOrder);
+        } catch (Exception e) {
+            // 주문 저장 실패 시 감소된 재고 원복
+            hubClient.increaseStocks(order.getProductId(), order.getQuantity());
         }
+
+        return null;
     }
 
     /**
@@ -180,9 +183,9 @@ public class OrderServiceImpl implements OrderService {
 
             // 재고 확인
             if (quantityDiff > 0) {
-                decreaseStocks(order.getProductId(), quantityDiff);
+                hubClient.decreaseStocks(order.getProductId(), quantityDiff);
             } else if (quantityDiff < 0)
-                productClient.increaseStocks(order.getProductId(), Math.abs(quantityDiff));
+                hubClient.increaseStocks(order.getProductId(), Math.abs(quantityDiff));
 
             // 총 금액 재계산
             newTotalPrice = product.getPrice().multiply(command.quantity());
@@ -197,7 +200,7 @@ public class OrderServiceImpl implements OrderService {
                     newTotalPrice
             );
         } catch (Exception e) {
-            // 재고 변동 시 원래 주문 수량으로 원복
+            // 주문 수정 오류 시 원래 주문 수량으로 원복
             if (quantityDiff != null)
                 rollbackStock(order.getProductId(), quantityDiff);
         }
@@ -205,12 +208,13 @@ public class OrderServiceImpl implements OrderService {
         return OrderDTO.from(order);
     }
 
+    // 재고 원복 로직
     private void rollbackStock(UUID productId, long quantityDiff) {
         try {
             if (quantityDiff > 0) {
-                productClient.increaseStocks(productId, quantityDiff);
+                hubClient.increaseStocks(productId, quantityDiff);
             } else if (quantityDiff < 0)
-                productClient.decreaseStocks(productId, Math.abs(quantityDiff));
+                hubClient.decreaseStocks(productId, Math.abs(quantityDiff));
 
         } catch (Exception e) {
             throw new CustomException(OrderErrorCode.PRODUCT_INTERNAL_SERVER_ERROR);

--- a/order-service/src/main/java/com/vroomvroom/orderservice/application/service/HubClient.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/application/service/HubClient.java
@@ -1,0 +1,14 @@
+package com.vroomvroom.orderservice.application.service;
+
+import com.vroomvroom.orderservice.infrastructure.dto.StockDTO;
+
+import java.util.UUID;
+
+public interface HubClient {
+
+    StockDTO getStockInfo(UUID hubId,UUID productId);
+
+    void decreaseStocks(UUID productId, long quantity);
+
+    void increaseStocks(UUID productId, long quantity);
+}

--- a/order-service/src/main/java/com/vroomvroom/orderservice/application/service/ProductClient.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/application/service/ProductClient.java
@@ -6,8 +6,4 @@ import java.util.UUID;
 
 public interface ProductClient {
     ProductDTO getProductInfo(UUID productId);
-
-    boolean decreaseStocks(UUID productId, long quantity);
-
-    void increaseStocks(UUID productId, long quantity);
 }

--- a/order-service/src/main/java/com/vroomvroom/orderservice/domain/entity/Order.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/domain/entity/Order.java
@@ -1,8 +1,10 @@
 package com.vroomvroom.orderservice.domain.entity;
 
+import com.vroomvroom.common.exception.CustomException;
 import com.vroomvroom.common.model.BaseTimeEntity;
 import com.vroomvroom.orderservice.domain.vo.Money;
 import com.vroomvroom.orderservice.domain.vo.OrderStatus;
+import com.vroomvroom.orderservice.exception.OrderErrorCode;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -80,7 +82,7 @@ public class Order extends BaseTimeEntity {
             LocalDateTime deadline,
             String requestNote
     ) {
-        validateCreateOrder(quantity, deadline, productPrice);
+        validateCreateOrder(supplyCompanyId, receiveCompanyId, quantity, deadline, productPrice);
 
         Money totalPrice = productPrice.multiply(quantity);
 
@@ -102,15 +104,18 @@ public class Order extends BaseTimeEntity {
     /**
      * 주문 유효성 검증
      */
-    private static void validateCreateOrder(Long quantity, LocalDateTime deadline, Money productPrice) {
+    private static void validateCreateOrder(UUID supplyCompanyId, UUID receiveCompanyId, Long quantity, LocalDateTime deadline, Money productPrice) {
+        if (supplyCompanyId == receiveCompanyId) {
+            throw new CustomException(OrderErrorCode.SAME_SUPPLY_RECEIVE_COMPANY);
+        }
         if (quantity == null || quantity < 1) {
-            throw new IllegalArgumentException("주문 수량은 1개 이상이어야 합니다");
+            throw new CustomException(OrderErrorCode.INVALID_ORDER_QUANTITY);
         }
         if (deadline == null || deadline.isBefore(LocalDateTime.now())) {
-            throw new IllegalArgumentException("납기일은 현재 시간 이후여야 합니다");
+            throw new CustomException(OrderErrorCode.INVALID_DEADLINE);
         }
         if (productPrice == null || productPrice.isZero()) {
-            throw new IllegalArgumentException("상품 가격은 0보다 커야 합니다");
+            throw new CustomException(OrderErrorCode.INVALID_PRICE);
         }
     }
 

--- a/order-service/src/main/java/com/vroomvroom/orderservice/domain/vo/Money.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/domain/vo/Money.java
@@ -5,7 +5,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.math.BigDecimal;
-import java.math.BigInteger;
 
 @Embeddable
 @Getter

--- a/order-service/src/main/java/com/vroomvroom/orderservice/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/exception/OrderErrorCode.java
@@ -35,12 +35,19 @@ public enum OrderErrorCode implements ErrorCode {
 
     // 외부 서비스 - 상품 서비스
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 상품입니다."),
-    PRODUCT_OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "상품 재고가 부족합니다."),
-    PRODUCT_STOCK_DECREASE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "상품 재고 감소에 실패했습니다."),
-    PRODUCT_STOCK_INCREASE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "상품 재고 증가에 실패했습니다."),
-    PRODUCT_STOCK_ROLLBACK_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "상품 재고 원복에 실패했습니다."),
     PRODUCT_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "상품 서비스에 연결할 수 없습니다."),
     PRODUCT_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "상품 서버 내부 오류가 발생했습니다."),
+
+    // 외부 서비스 - 허브 서비스
+    HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 허브입니다."),
+    STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "재고가 존재하지 않습니다."),
+    HUB_OR_STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "허브 또는 재고가 존재하지 않습니다."),
+    HUB_PRODUCT_OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "상품 재고가 부족합니다."),
+    HUB_PRODUCT_STOCK_DECREASE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "상품 재고 감소에 실패했습니다."),
+    HUB_PRODUCT_STOCK_INCREASE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "상품 재고 증가에 실패했습니다."),
+    HUB_PRODUCT_STOCK_ROLLBACK_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "상품 재고 원복에 실패했습니다."),
+    HUB_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "상품 서비스에 연결할 수 없습니다."),
+    HUB_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "상품 서버 내부 오류가 발생했습니다."),
 
     // 외부 서비스 - 배송 서비스
     DELIVERY_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "배송 생성에 실패했습니다."),

--- a/order-service/src/main/java/com/vroomvroom/orderservice/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/exception/OrderErrorCode.java
@@ -1,0 +1,59 @@
+package com.vroomvroom.orderservice.exception;
+
+import com.vroomvroom.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum OrderErrorCode implements ErrorCode {
+
+    // 공통 에러
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "주문 서버 내부 오류가 발생했습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 경로를 찾을 수 없습니다."),
+    NOT_RESOURCE_OWNER(HttpStatus.FORBIDDEN, "해당 리소스 소유자가 아닙니다."),
+
+    // Validation
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "요청 데이터의 형식이 유효하지 않습니다."),
+
+    // 주문 관련 에러
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 주문입니다."),
+    ORDER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 주문입니다."),
+    ORDER_NOT_CANCELLABLE(HttpStatus.BAD_REQUEST, "취소 가능한 상태의 주문이 아닙니다."),
+    ORDER_NOT_MODIFIABLE(HttpStatus.BAD_REQUEST, "수정 가능한 상태의 주문이 아닙니다."),
+    ORDER_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "주문 생성에 실패했습니다."),
+    ORDER_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "주문 수정에 실패했습니다."),
+
+    // 외부 서비스 - 업체 서비스
+    COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 업체입니다."),
+    COMPANY_HUB_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "업체의 허브 정보를 찾을 수 없습니다."),
+    COMPANY_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "업체 서비스에 연결할 수 없습니다."),
+    COMPANY_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "업체 서버 내부 오류가 발생했습니다."),
+
+    // 외부 서비스 - 상품 서비스
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 상품입니다."),
+    PRODUCT_OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "상품 재고가 부족합니다."),
+    PRODUCT_STOCK_DECREASE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "상품 재고 감소에 실패했습니다."),
+    PRODUCT_STOCK_INCREASE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "상품 재고 증가에 실패했습니다."),
+    PRODUCT_STOCK_ROLLBACK_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "상품 재고 원복에 실패했습니다."),
+    PRODUCT_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "상품 서비스에 연결할 수 없습니다."),
+    PRODUCT_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "상품 서버 내부 오류가 발생했습니다."),
+
+    // 외부 서비스 - 배송 서비스
+    DELIVERY_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "배송 생성에 실패했습니다."),
+    DELIVERY_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "배송 서비스에 연결할 수 없습니다."),
+    DELIVERY_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "배송 서버 내부 오류가 발생했습니다."),
+
+    // 비즈니스 로직 에러
+    INVALID_ORDER_QUANTITY(HttpStatus.BAD_REQUEST, "주문 수량은 1개 이상이어야 합니다."),
+    INVALID_DEADLINE(HttpStatus.BAD_REQUEST, "납기일은 현재 시간 이후여야 합니다."),
+    INVALID_PRICE(HttpStatus.BAD_REQUEST, "주문 금액이 올바르지 않습니다."),
+    SAME_SUPPLY_RECEIVE_COMPANY(HttpStatus.BAD_REQUEST, "공급 업체와 수령 업체가 동일할 수 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/dto/StockDTO.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/dto/StockDTO.java
@@ -1,0 +1,18 @@
+package com.vroomvroom.orderservice.infrastructure.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StockDTO {
+    UUID hubId;
+    UUID stockId;
+    Long quantity;
+}

--- a/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/external/CompanyClientImpl.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/external/CompanyClientImpl.java
@@ -1,16 +1,52 @@
 package com.vroomvroom.orderservice.infrastructure.external;
 
+import com.vroomvroom.common.api.ApiResponse;
+import com.vroomvroom.common.exception.CustomException;
 import com.vroomvroom.orderservice.application.service.CompanyClient;
+import com.vroomvroom.orderservice.exception.OrderErrorCode;
 import com.vroomvroom.orderservice.infrastructure.dto.CompanyHubDTO;
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
 
+@Slf4j
 @Component
+@RequiredArgsConstructor
 public class CompanyClientImpl implements CompanyClient {
+
+    private final CompanyFeignClient companyFeignClient;
+
     @Override
     public CompanyHubDTO getCompanyHubInfo(UUID companyId) {
-        // TODO. FeignClient를 통한 API 호출
+        log.info("업체 정보 조회 요청 : companyId = {}", companyId);
+
+        // TODO. EUREKA Server 적용 필요
+        /*
+        try {
+            ApiResponse<CompanyHubDTO> response = companyFeignClient.getCompanyHubInfo(companyId);
+
+            if (!response.isSuccess() || response.getData() == null) {
+                log.error("업체 정보 조회 실패 : companyId = {}", companyId);
+                throw new CustomException(OrderErrorCode.COMPANY_NOT_FOUND);
+            }
+
+            log.info("업체 허브 정보 조회 성공: companyId={}, hubId={}",
+                    companyId, response.getData().getHubId());
+
+            return response.getData();
+        } catch (FeignException.NotFound e) {
+            log.error("업체를 찾을 수 없음 : companyId = {}", companyId);
+            throw new CustomException(OrderErrorCode.COMPANY_NOT_FOUND);
+        } catch (FeignException e) {
+            log.error("업체 서비스 호출 실패 : status={}, message={}", e.status(), e.getMessage());
+            throw new CustomException(OrderErrorCode.COMPANY_SERVICE_UNAVAILABLE);
+        }
+         */
+
+        // TODO. EUREKA Server 적용 시 삭제
         return CompanyHubDTO.builder()
                 .companyId(companyId)
                 .hubId(UUID.randomUUID()) // TODO. 허브 ID 반영 필요

--- a/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/external/CompanyFeignClient.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/external/CompanyFeignClient.java
@@ -1,0 +1,21 @@
+package com.vroomvroom.orderservice.infrastructure.external;
+
+import com.vroomvroom.common.api.ApiResponse;
+import com.vroomvroom.orderservice.infrastructure.dto.CompanyHubDTO;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.UUID;
+
+@FeignClient(
+        name = "company-service",
+        path = "/api/v1/companies"
+)
+public interface CompanyFeignClient {
+    /**
+     * 업체의 소속 허브 정보 조회
+     */
+    @GetMapping("/{companyId}")
+    ApiResponse<CompanyHubDTO> getCompanyHubInfo(@PathVariable UUID companyId);
+}

--- a/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/external/HubClientImpl.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/external/HubClientImpl.java
@@ -1,0 +1,85 @@
+package com.vroomvroom.orderservice.infrastructure.external;
+
+import com.vroomvroom.common.api.ApiResponse;
+import com.vroomvroom.common.exception.CustomException;
+import com.vroomvroom.orderservice.application.service.HubClient;
+import com.vroomvroom.orderservice.exception.OrderErrorCode;
+import com.vroomvroom.orderservice.infrastructure.dto.StockDTO;
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HubClientImpl implements HubClient {
+
+    private final HubFeignClient hubFeignClient;
+
+    @Override
+    public StockDTO getStockInfo(UUID hubId, UUID productId) {
+        log.info("재고 조회 요청 : hubId={}", hubId);
+        try {
+            ApiResponse<StockDTO> response = hubFeignClient.getStockInfo(hubId, productId);
+
+            if (!response.isSuccess() || response.getData() == null) {
+                log.error("재고 조회 실패 : hubId = {}", hubId);
+                throw new CustomException(OrderErrorCode.STOCK_NOT_FOUND);
+            }
+
+            log.info("재고 정보 조회 성공 : hubId = {}", hubId);
+            return response.getData();
+        } catch (FeignException.NotFound e) {
+            log.error("재고를 찾을 수 없음 : hubId = {}", hubId);
+            throw new CustomException(OrderErrorCode.STOCK_NOT_FOUND);
+        } catch (FeignException e) {
+            log.error("허브 서비스 호출 실패 : status={}, message={}", e.status(), e.getMessage());
+            throw new CustomException(OrderErrorCode.HUB_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Override
+    public void decreaseStocks(UUID productId, long quantity) {
+        log.info("재고 감소 요청 : productId={}, quantity={}", productId, quantity);
+
+        /*
+        try {
+            ApiResponse<Void> response =
+                    hubFeignClient.decreaseStock(productId, quantity);
+
+            if (!response.isSuccess()) {
+                log.error("재고 감소 실패: productId={}, quantity={}",
+                        productId, quantity);
+            }
+
+        } catch (FeignException.BadRequest e) {
+            log.error("재고 부족: productId={}, quantity={}", productId, quantity);
+            throw new CustomException(OrderErrorCode.BAD_REQUEST);
+
+        } catch (FeignException e) {
+            log.error("재고 감소 API 호출 실패: status={}, message={}",
+                    e.status(), e.getMessage());
+            throw new CustomException(OrderErrorCode.INTERNAL_SERVER_ERROR);
+        }
+        */
+    }
+
+    @Override
+    public void increaseStocks(UUID productId, long quantity) {
+        log.info("재고 증가 요청 : productId={}, quantity={}", productId, quantity);
+
+        /*
+        try {
+            hubFeignClient.increaseStock(productId, quantity);
+            log.info("재고 증가 성공: productId={}, quantity={}", productId, quantity);
+
+        } catch (FeignException e) {
+            log.error("재고 증가 실패: productId={}, quantity={}, status={}, message={}",
+                    productId, quantity, e.status(), e.getMessage());
+        }
+        */
+    }
+}

--- a/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/external/HubClientImpl.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/external/HubClientImpl.java
@@ -22,6 +22,7 @@ public class HubClientImpl implements HubClient {
     @Override
     public StockDTO getStockInfo(UUID hubId, UUID productId) {
         log.info("재고 조회 요청 : hubId={}", hubId);
+        /*
         try {
             ApiResponse<StockDTO> response = hubFeignClient.getStockInfo(hubId, productId);
 
@@ -39,6 +40,13 @@ public class HubClientImpl implements HubClient {
             log.error("허브 서비스 호출 실패 : status={}, message={}", e.status(), e.getMessage());
             throw new CustomException(OrderErrorCode.HUB_INTERNAL_SERVER_ERROR);
         }
+        */
+
+        return StockDTO.builder()
+                .hubId(UUID.randomUUID())
+                .stockId(UUID.randomUUID())
+                .quantity(10L)
+                .build();
     }
 
     @Override

--- a/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/external/HubFeignClient.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/external/HubFeignClient.java
@@ -1,0 +1,44 @@
+package com.vroomvroom.orderservice.infrastructure.external;
+
+import com.vroomvroom.common.api.ApiResponse;
+import com.vroomvroom.orderservice.infrastructure.dto.StockDTO;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.UUID;
+
+@FeignClient(
+        name = "hub-service",
+        path = "/api/v1/stock"
+)
+public interface HubFeignClient {
+    /**
+     * 재고 확인
+     */
+    @GetMapping("/{hubId}/stock/{productId}")
+    ApiResponse<StockDTO> getStockInfo(
+            @PathVariable UUID hubId,
+            @PathVariable UUID productId
+    );
+
+    /**
+     * 재고 감소
+     */
+    @PostMapping("/{hubId}/stock/decrease")
+    ApiResponse<Void> decreaseStock(
+            @PathVariable UUID hubId,
+            @RequestParam Long quantity
+    );
+
+    /**
+     * 재고 증가
+     */
+    @PostMapping("/{hubId}/stock/increase")
+    ApiResponse<Void> increaseStock(
+            @PathVariable UUID hubId,
+            @RequestParam Long quantity
+    );
+}

--- a/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/external/ProductClientImpl.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/external/ProductClientImpl.java
@@ -1,17 +1,51 @@
 package com.vroomvroom.orderservice.infrastructure.external;
 
+import com.vroomvroom.common.api.ApiResponse;
+import com.vroomvroom.common.exception.CustomException;
 import com.vroomvroom.orderservice.application.service.ProductClient;
 import com.vroomvroom.orderservice.domain.vo.Money;
+import com.vroomvroom.orderservice.exception.OrderErrorCode;
 import com.vroomvroom.orderservice.infrastructure.dto.ProductDTO;
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
 
+@Slf4j
 @Component
+@RequiredArgsConstructor
 public class ProductClientImpl implements ProductClient {
+
+    private final ProductFeignClient productFeignClient;
+
     @Override
     public ProductDTO getProductInfo(UUID productId) {
-        // TODO. FeignClient를 통한 API 호출
+        log.info("상품 정보 조회 요청 : productId = {}", productId);
+
+        // TODO. EUREKA Server 적용 필요
+        /*
+        try {
+            ApiResponse<ProductDTO> response = productFeignClient.getProductInfo(productId);
+
+            if (!response.isSuccess() || response.getData() == null) {
+                log.error("상품 정보 조회 실패 : productId = {}", productId);
+                throw new CustomException(OrderErrorCode.PRODUCT_INTERNAL_SERVER_ERROR);
+            }
+
+            log.info("상품 정보 조회 성공 : productId = {}", productId);
+            return response.getData();
+        } catch (FeignException.NotFound e) {
+            log.error("상품을 찾을 수 없음 : productId = {}", productId);
+            throw new CustomException(OrderErrorCode.PRODUCT_NOT_FOUND);
+        } catch (FeignException e) {
+            log.error("상품 서비스 호출 실패 : status={}, message={}", e.status(), e.getMessage());
+            throw new CustomException(OrderErrorCode.PRODUCT_SERVICE_UNAVAILABLE);
+        }
+        */
+
+        // TODO. EUREKA Server 적용 시 삭제
         return ProductDTO.builder()
                 .productId(productId)
                 .price(Money.of(10000)) // TODO. 상품 가격 반영 필요
@@ -21,12 +55,48 @@ public class ProductClientImpl implements ProductClient {
 
     @Override
     public boolean decreaseStocks(UUID productId, long quantity) {
-        // TODO. FeignClient를 통한 재고 감소 API 호출?
+        log.info("재고 감소 요청 : productId={}, quantity={}", productId, quantity);
+
+        /*
+        try {
+            ApiResponse<Boolean> response =
+                    productFeignClient.decreaseStock(productId, quantity);
+
+            if (!response.isSuccess()) {
+                log.error("재고 감소 실패: productId={}, quantity={}",
+                        productId, quantity);
+                return false;
+            }
+
+            return response.getData() != null && response.getData();
+
+        } catch (FeignException.BadRequest e) {
+            log.error("재고 부족: productId={}, quantity={}", productId, quantity);
+            throw new CustomException(OrderErrorCode.BAD_REQUEST);
+
+        } catch (FeignException e) {
+            log.error("재고 감소 API 호출 실패: status={}, message={}",
+                    e.status(), e.getMessage());
+            throw new CustomException(OrderErrorCode.INTERNAL_SERVER_ERROR);
+        }
+        */
+
         return true;
     }
 
     @Override
     public void increaseStocks(UUID productId, long quantity) {
-        // TODO. FeignClient를 통한 재고 증가 API 호출?
+        log.info("재고 증가 요청 : productId={}, quantity={}", productId, quantity);
+
+        /*
+        try {
+            productFeignClient.increaseStock(productId, quantity);
+            log.info("재고 증가 성공: productId={}, quantity={}", productId, quantity);
+
+        } catch (FeignException e) {
+            log.error("재고 증가 실패: productId={}, quantity={}, status={}, message={}",
+                    productId, quantity, e.status(), e.getMessage());
+        }
+        */
     }
 }

--- a/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/external/ProductClientImpl.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/external/ProductClientImpl.java
@@ -1,12 +1,8 @@
 package com.vroomvroom.orderservice.infrastructure.external;
 
-import com.vroomvroom.common.api.ApiResponse;
-import com.vroomvroom.common.exception.CustomException;
 import com.vroomvroom.orderservice.application.service.ProductClient;
 import com.vroomvroom.orderservice.domain.vo.Money;
-import com.vroomvroom.orderservice.exception.OrderErrorCode;
 import com.vroomvroom.orderservice.infrastructure.dto.ProductDTO;
-import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -51,52 +47,5 @@ public class ProductClientImpl implements ProductClient {
                 .price(Money.of(10000)) // TODO. 상품 가격 반영 필요
                 .stock(10L) // TODO. 상품 재고 반영 필요
                 .build();
-    }
-
-    @Override
-    public boolean decreaseStocks(UUID productId, long quantity) {
-        log.info("재고 감소 요청 : productId={}, quantity={}", productId, quantity);
-
-        /*
-        try {
-            ApiResponse<Boolean> response =
-                    productFeignClient.decreaseStock(productId, quantity);
-
-            if (!response.isSuccess()) {
-                log.error("재고 감소 실패: productId={}, quantity={}",
-                        productId, quantity);
-                return false;
-            }
-
-            return response.getData() != null && response.getData();
-
-        } catch (FeignException.BadRequest e) {
-            log.error("재고 부족: productId={}, quantity={}", productId, quantity);
-            throw new CustomException(OrderErrorCode.BAD_REQUEST);
-
-        } catch (FeignException e) {
-            log.error("재고 감소 API 호출 실패: status={}, message={}",
-                    e.status(), e.getMessage());
-            throw new CustomException(OrderErrorCode.INTERNAL_SERVER_ERROR);
-        }
-        */
-
-        return true;
-    }
-
-    @Override
-    public void increaseStocks(UUID productId, long quantity) {
-        log.info("재고 증가 요청 : productId={}, quantity={}", productId, quantity);
-
-        /*
-        try {
-            productFeignClient.increaseStock(productId, quantity);
-            log.info("재고 증가 성공: productId={}, quantity={}", productId, quantity);
-
-        } catch (FeignException e) {
-            log.error("재고 증가 실패: productId={}, quantity={}, status={}, message={}",
-                    productId, quantity, e.status(), e.getMessage());
-        }
-        */
     }
 }

--- a/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/external/ProductFeignClient.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/external/ProductFeignClient.java
@@ -1,0 +1,47 @@
+package com.vroomvroom.orderservice.infrastructure.external;
+
+import com.vroomvroom.common.api.ApiResponse;
+import com.vroomvroom.orderservice.infrastructure.dto.ProductDTO;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@FeignClient(
+        name = "product-service",
+        path = "/api/v1/products"
+)
+public interface ProductFeignClient {
+    /**
+     * 상품 정보 조회
+     */
+    @GetMapping("/{productId}")
+    ApiResponse<ProductDTO> getProductInfo(@PathVariable UUID productId);
+
+    /**
+     * 재고 감소
+     */
+    @PostMapping("/{productId}/stock/decrease")
+    ApiResponse<Boolean> decreaseStock(
+            @PathVariable UUID productId,
+            @RequestParam Long quantity
+    );
+
+    /**
+     * 재고 증가
+     */
+    @PostMapping("/{productId}/stock/increase")
+    ApiResponse<Void> increaseStock(
+            @PathVariable UUID productId,
+            @RequestParam Long quantity
+    );
+
+    /**
+     * 재고 확인
+     */
+    @GetMapping("/{productId}/stock/check")
+    ApiResponse<Boolean> checkStock(
+            @PathVariable UUID productId,
+            @RequestParam Long quantity
+    );
+}

--- a/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/external/ProductFeignClient.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/external/ProductFeignClient.java
@@ -17,31 +17,4 @@ public interface ProductFeignClient {
      */
     @GetMapping("/{productId}")
     ApiResponse<ProductDTO> getProductInfo(@PathVariable UUID productId);
-
-    /**
-     * 재고 감소
-     */
-    @PostMapping("/{productId}/stock/decrease")
-    ApiResponse<Boolean> decreaseStock(
-            @PathVariable UUID productId,
-            @RequestParam Long quantity
-    );
-
-    /**
-     * 재고 증가
-     */
-    @PostMapping("/{productId}/stock/increase")
-    ApiResponse<Void> increaseStock(
-            @PathVariable UUID productId,
-            @RequestParam Long quantity
-    );
-
-    /**
-     * 재고 확인
-     */
-    @GetMapping("/{productId}/stock/check")
-    ApiResponse<Boolean> checkStock(
-            @PathVariable UUID productId,
-            @RequestParam Long quantity
-    );
 }


### PR DESCRIPTION
# [FEAT] 주문 서비스 ErrorCode 체계화 및 FeignClient 구조 구현

## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #56 

## 📌 개요
주문 서비스의 에러 처리를 체계화하고 외부 서비스 연동을 위한 FeignClient 구조를 완성했습니다.

## 🔁 변경 사항

### ErrorCode 체계 개편
- **Common ErrorCode 인터페이스 활용**
  - 기존 order-service 전용 ErrorCode, CustomException, GlobalExceptionHandler 삭제
  - common-lib의 ErrorCode 인터페이스를 구현하는 `OrderErrorCode` enum 생성
  - 모든 마이크로서비스가 동일한 에러 응답 구조 사용

- **OrderErrorCode 구조화**
  - **공통 에러**: INTERNAL_SERVER_ERROR, METHOD_NOT_ALLOWED, BAD_REQUEST 등
  - **주문 관련 에러**: ORDER_NOT_FOUND, ORDER_NOT_CANCELLABLE, ORDER_NOT_MODIFIABLE 등
  - **외부 서비스 - 업체**: COMPANY_NOT_FOUND, COMPANY_SERVICE_UNAVAILABLE 등
  - **외부 서비스 - 상품**: PRODUCT_NOT_FOUND, PRODUCT_OUT_OF_STOCK, PRODUCT_STOCK_DECREASE_FAILED 등
  - **외부 서비스 - 배송**: DELIVERY_CREATION_FAILED, DELIVERY_SERVICE_UNAVAILABLE 등
  - **비즈니스 로직**: INVALID_ORDER_QUANTITY, INVALID_DEADLINE, SAME_SUPPLY_RECEIVE_COMPANY 등

### 도메인 검증 강화
- **Order.validateCreateOrder() 개선**
  - IllegalArgumentException → CustomException(OrderErrorCode) 사용
  - 공급/수령 업체 동일 여부 검증 추가 (`SAME_SUPPLY_RECEIVE_COMPANY`)
  - 각 검증 항목마다 명확한 ErrorCode 매핑

### Service 계층 에러 처리 개선
- **모든 RuntimeException → CustomException 변환**
  - `decreaseStocks()`: PRODUCT_STOCK_DECREASE_FAILED, PRODUCT_INTERNAL_SERVER_ERROR
  - `getOrder()`: ORDER_NOT_FOUND
  - `cancelOrder()`: ORDER_NOT_FOUND, ORDER_NOT_CANCELLABLE
  - `updateOrder()`: ORDER_NOT_FOUND, ORDER_NOT_MODIFIABLE
  - `rollbackStock()`: PRODUCT_INTERNAL_SERVER_ERROR

### FeignClient 구조 구현
- **CompanyFeignClient 생성**
  - `getCompanyHubInfo(UUID companyId)`: 업체의 소속 허브 정보 조회
  - @FeignClient(name = "company-service", path = "/api/v1/companies")

- **ProductFeignClient 생성**
  - `getProductInfo(UUID productId)`: 상품 정보 조회
  - `decreaseStock(UUID productId, Long quantity)`: 재고 감소
  - `increaseStock(UUID productId, Long quantity)`: 재고 증가
  - `checkStock(UUID productId, Long quantity)`: 재고 확인
  - @FeignClient(name = "product-service", path = "/api/v1/products")

### External Client 구현 개선
- **CompanyClientImpl**
  - FeignClient 호출 로직 구현 (주석 처리)
  - FeignException 처리: NotFound → COMPANY_NOT_FOUND, 기타 → COMPANY_SERVICE_UNAVAILABLE
  - 응답 검증 로직 추가
  - 상세한 로깅 (요청/성공/실패)

- **ProductClientImpl**
  - FeignClient 호출 로직 구현 (주석 처리)
  - decreaseStocks(): BadRequest → PRODUCT_OUT_OF_STOCK 처리
  - increaseStocks(): 재고 증가 실패 시 로깅
  - TODO: EUREKA Server 적용 시 주석 해제 예정

### ApiResponse 개선
- **fail() 메서드 수정**
  - `errorCode.name()` → `errorCode.getHttpStatus().name()` 으로 변경
  - code 필드에 "BAD_REQUEST", "NOT_FOUND" 등 HTTP 상태 이름 반환
  - ErrorCode enum 이름 대신 HTTP 상태로 통일

### 설정 추가
- **@EnableFeignClients**: OrderServiceApplication에 추가

## 📸 스크린샷
- 테스트 성공한 스크린샷은 노션 API 명세서에 올려주세요

## 👀 기타 더 이야기해볼 점
- **Eureka 연동 대기**: 현재 FeignClient 코드가 모두 주석 처리되어 있으며, 더미 데이터를 반환합니다. Eureka Server 구축 후 주석을 해제하고 실제 통신을 테스트해야 합니다.

- 각 외부 서비스의 엔드포인트는 일단 임시로 설정했습니다. 추후 구현되면 맞춰서 반영하도록 하겠습니다.

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.