### PR TITLE
[FEAT] 주문 생성 Kafka 이벤트 발행 및 Swagger 문서화 추가

### DIFF
--- a/common-lib/build.gradle
+++ b/common-lib/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.17.1'
 
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+
     // Lombok
     compileOnly 'org.projectlombok:lombok:1.18.34'
     annotationProcessor 'org.projectlombok:lombok:1.18.34'

--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.kafka:spring-kafka'
 
     runtimeOnly 'org.postgresql:postgresql'
 

--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
     runtimeOnly 'org.postgresql:postgresql'
 

--- a/order-service/src/main/java/com/vroomvroom/orderservice/application/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/application/OrderServiceImpl.java
@@ -9,6 +9,8 @@ import com.vroomvroom.orderservice.application.service.CompanyClient;
 import com.vroomvroom.orderservice.application.service.HubClient;
 import com.vroomvroom.orderservice.application.service.ProductClient;
 import com.vroomvroom.orderservice.domain.entity.Order;
+import com.vroomvroom.orderservice.domain.event.OrderCreatedEvent;
+import com.vroomvroom.orderservice.domain.port.OrderEventPublisher;
 import com.vroomvroom.orderservice.domain.repository.OrderRepository;
 import com.vroomvroom.orderservice.domain.vo.Money;
 import com.vroomvroom.orderservice.domain.vo.OrderStatus;
@@ -22,6 +24,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.UUID;
 
@@ -34,6 +38,7 @@ public class OrderServiceImpl implements OrderService {
     private final ProductClient productClient;
     private final CompanyClient companyClient;
     private final HubClient hubClient;
+    private final OrderEventPublisher orderEventPublisher;
 
     /**
      * 주문 생성
@@ -53,6 +58,10 @@ public class OrderServiceImpl implements OrderService {
         ProductDTO product = productClient.getProductInfo(command.productId());
         StockDTO stock = hubClient.getStockInfo(supplyCompany.getHubId(), product.getProductId());
 
+        // 공급/수량 업체 동일 여부 검증
+        if (supplyCompany.getCompanyId().equals(receiveCompany.getCompanyId()))
+            throw new CustomException(OrderErrorCode.SAME_SUPPLY_RECEIVE_COMPANY);
+        // 재고 수량 확인
         if (stock.getQuantity() <= 0)
             throw new CustomException(OrderErrorCode.HUB_PRODUCT_OUT_OF_STOCK);
 
@@ -72,22 +81,51 @@ public class OrderServiceImpl implements OrderService {
         // 재고 차감
         hubClient.decreaseStocks(order.getProductId(), order.getQuantity());
 
-        Order savedOrder = null;
         try {
             // 주문 저장
-            savedOrder = orderRepository.save(order);
+            Order savedOrder = orderRepository.save(order);
 
-            if (savedOrder == null)
-                hubClient.decreaseStocks(order.getProductId(), order.getQuantity());
+            // 트랜잭션 커밋 후 이벤트 발행
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    publishOrderCreatedEvent(savedOrder);
+                }
+            });
 
             log.info("주문 생성 성공 - 주문 ID={}", savedOrder.getId());
             return OrderDTO.from(savedOrder);
+
         } catch (Exception e) {
             // 주문 저장 실패 시 감소된 재고 원복
             hubClient.increaseStocks(order.getProductId(), order.getQuantity());
         }
 
         return null;
+    }
+
+    // 주문 생성 이벤트 발행
+    private void publishOrderCreatedEvent(Order order) {
+        try {
+            OrderCreatedEvent event = OrderCreatedEvent.from(
+                    order.getId(),
+                    order.getSupplyCompanyId(),
+                    order.getReceiveCompanyId(),
+                    order.getSupplyHubId(),
+                    order.getReceiveHubId(),
+                    order.getProductId(),
+                    order.getTotalPrice().getAmount(),
+                    order.getQuantity(),
+                    order.getDeadline(),
+                    order.getRequestNote()
+            );
+
+            orderEventPublisher.publishOrderCreated(order.getId(), event);
+            log.info("주문 생성 이벤트 발행 완료 - orderId: {}", order.getId());
+
+        } catch (Exception e) {
+            log.error("주문 생성 이벤트 발행 실패 - orderId: {}", order.getId(), e);
+        }
     }
 
     /**

--- a/order-service/src/main/java/com/vroomvroom/orderservice/application/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/application/OrderServiceImpl.java
@@ -109,15 +109,8 @@ public class OrderServiceImpl implements OrderService {
         try {
             OrderCreatedEvent event = OrderCreatedEvent.from(
                     order.getId(),
-                    order.getSupplyCompanyId(),
-                    order.getReceiveCompanyId(),
                     order.getSupplyHubId(),
-                    order.getReceiveHubId(),
-                    order.getProductId(),
-                    order.getTotalPrice().getAmount(),
-                    order.getQuantity(),
-                    order.getDeadline(),
-                    order.getRequestNote()
+                    order.getReceiveHubId()
             );
 
             orderEventPublisher.publishOrderCreated(order.getId(), event);

--- a/order-service/src/main/java/com/vroomvroom/orderservice/application/event/KafkaOrderEventHandler.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/application/event/KafkaOrderEventHandler.java
@@ -1,0 +1,51 @@
+package com.vroomvroom.orderservice.application.event;
+
+import com.vroomvroom.common.exception.CustomException;
+import com.vroomvroom.orderservice.domain.event.OrderCreatedEvent;
+import com.vroomvroom.orderservice.domain.port.OrderEventPublisher;
+import com.vroomvroom.orderservice.exception.OrderErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaOrderEventHandler implements OrderEventPublisher {
+
+    @Value("${app.kafka.topics.order-created}")
+    private String orderCreatedTopic;
+
+    private final KafkaTemplate<String, OrderCreatedEvent> orderEventKafkaTemplate;
+
+    @Override
+    public void publishOrderCreated(UUID orderId, OrderCreatedEvent event) {
+        try {
+            log.info("주문 생성 이벤트 시작 - orderId={}", orderId);
+
+            CompletableFuture<SendResult<String, OrderCreatedEvent>> future =
+                    orderEventKafkaTemplate.send(orderCreatedTopic, orderId.toString(), event);
+
+            future.whenComplete((result, ex) -> {
+                if (ex == null) {
+                    log.info("주문 생성 이벤트 발행 성공 - orderId: {}, partition: {}, offset: {}",
+                            orderId,
+                            result.getRecordMetadata().partition(),
+                            result.getRecordMetadata().offset());
+                } else {
+                    log.error("주문 생성 이벤트 발행 실패 - orderId: {}", orderId, ex);
+                    // 실패 시 보상 트랜잭션 또는 재시도 로직 필요
+                }
+            });
+        } catch (Exception e) {
+            log.error("주문 생성 이벤트 발행 중 예외 발생 - orderId: {}", orderId, e);
+            throw new CustomException(OrderErrorCode.KAFKA_RUNTIME_EXCEPTION);
+        }
+    }
+}

--- a/order-service/src/main/java/com/vroomvroom/orderservice/domain/event/OrderCreatedEvent.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/domain/event/OrderCreatedEvent.java
@@ -1,0 +1,58 @@
+package com.vroomvroom.orderservice.domain.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 주문 생성 이벤트
+ * 배송 서비스로 전달되는 이벤트 페이로드
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderCreatedEvent {
+    private UUID orderId;
+    private UUID supplyCompanyId;
+    private UUID receiveCompanyId;
+    private UUID supplyHubId;
+    private UUID receiveHubId;
+    private UUID productId;
+    private BigDecimal totalPrice;
+    private Long quantity;
+    private LocalDateTime deadline;
+    private String requestNote;
+
+    /**
+     * 주문 생성 이벤트 팩토리 메서드
+     */
+    public static OrderCreatedEvent from(
+            UUID orderId,
+            UUID supplyCompanyId,
+            UUID receiveCompanyId,
+            UUID supplyHubId,
+            UUID receiveHubId,
+            UUID productId,
+            BigDecimal totalPrice,
+            Long quantity,
+            LocalDateTime deadline,
+            String requestNote
+    ) {
+        return new OrderCreatedEvent(
+                orderId,
+                supplyCompanyId,
+                receiveCompanyId,
+                supplyHubId,
+                receiveHubId,
+                productId,
+                totalPrice,
+                quantity,
+                deadline,
+                requestNote
+        );
+    }
+}

--- a/order-service/src/main/java/com/vroomvroom/orderservice/domain/event/OrderCreatedEvent.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/domain/event/OrderCreatedEvent.java
@@ -4,8 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 /**
@@ -17,42 +15,21 @@ import java.util.UUID;
 @AllArgsConstructor
 public class OrderCreatedEvent {
     private UUID orderId;
-    private UUID supplyCompanyId;
-    private UUID receiveCompanyId;
     private UUID supplyHubId;
     private UUID receiveHubId;
-    private UUID productId;
-    private BigDecimal totalPrice;
-    private Long quantity;
-    private LocalDateTime deadline;
-    private String requestNote;
 
     /**
      * 주문 생성 이벤트 팩토리 메서드
      */
     public static OrderCreatedEvent from(
             UUID orderId,
-            UUID supplyCompanyId,
-            UUID receiveCompanyId,
             UUID supplyHubId,
-            UUID receiveHubId,
-            UUID productId,
-            BigDecimal totalPrice,
-            Long quantity,
-            LocalDateTime deadline,
-            String requestNote
+            UUID receiveHubId
     ) {
         return new OrderCreatedEvent(
                 orderId,
-                supplyCompanyId,
-                receiveCompanyId,
                 supplyHubId,
-                receiveHubId,
-                productId,
-                totalPrice,
-                quantity,
-                deadline,
-                requestNote
+                receiveHubId
         );
     }
 }

--- a/order-service/src/main/java/com/vroomvroom/orderservice/domain/port/OrderEventPublisher.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/domain/port/OrderEventPublisher.java
@@ -1,0 +1,15 @@
+package com.vroomvroom.orderservice.domain.port;
+
+import com.vroomvroom.orderservice.domain.event.OrderCreatedEvent;
+
+import java.util.UUID;
+
+public interface OrderEventPublisher {
+    /**
+     * 주문 생성 이벤트 발행
+     *
+     * @param orderId 주문 ID
+     * @param event   주문 생성 이벤트
+     */
+    void publishOrderCreated(UUID orderId, OrderCreatedEvent event);
+}

--- a/order-service/src/main/java/com/vroomvroom/orderservice/exception/OrderErrorCode.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/exception/OrderErrorCode.java
@@ -59,6 +59,8 @@ public enum OrderErrorCode implements ErrorCode {
     INVALID_DEADLINE(HttpStatus.BAD_REQUEST, "납기일은 현재 시간 이후여야 합니다."),
     INVALID_PRICE(HttpStatus.BAD_REQUEST, "주문 금액이 올바르지 않습니다."),
     SAME_SUPPLY_RECEIVE_COMPANY(HttpStatus.BAD_REQUEST, "공급 업체와 수령 업체가 동일할 수 없습니다."),
+
+    KAFKA_RUNTIME_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "주문 이벤트 발행을 실패했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/config/KafkaProducerConfig.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/config/KafkaProducerConfig.java
@@ -1,0 +1,45 @@
+package com.vroomvroom.orderservice.infrastructure.config;
+
+import com.vroomvroom.orderservice.domain.event.OrderCreatedEvent;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, OrderCreatedEvent> orderEventProducerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+
+        // 메시지 전송 실패 시 재시도
+        configProps.put(ProducerConfig.RETRIES_CONFIG, 3);
+        configProps.put(ProducerConfig.ACKS_CONFIG, "all");
+
+        return new DefaultKafkaProducerFactory<>(configProps);
+
+    }
+
+    @Bean
+    public KafkaTemplate<String, OrderCreatedEvent> orderEventKafkaTemplate() {
+        return new KafkaTemplate<>(orderEventProducerFactory());
+    }
+}

--- a/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/config/SwaggerConfig.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,52 @@
+package com.vroomvroom.orderservice.infrastructure.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(apiInfo())
+                .servers(List.of(
+                        new Server()
+                                .url("http://localhost:8080")
+                                .description("Local Server")
+                ))
+                .components(securityComponents())
+                .addSecurityItem(securityRequirement());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("vroomvroom-msa")
+                .description("물류 관리 시스템 API 문서")
+                .version("v1.0.0");
+    }
+
+    private Components securityComponents() {
+        return new Components()
+                .addSecuritySchemes("bearerAuth",
+                        new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(SecurityScheme.In.HEADER)
+                                .name("Authorization")
+                );
+    }
+
+    private SecurityRequirement securityRequirement() {
+        return new SecurityRequirement().addList("bearerAuth");
+    }
+}

--- a/order-service/src/main/java/com/vroomvroom/orderservice/presentation/OrderController.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/presentation/OrderController.java
@@ -7,6 +7,7 @@ import com.vroomvroom.orderservice.application.command.CancelOrderCommand;
 import com.vroomvroom.orderservice.application.command.CreateOrderCommand;
 import com.vroomvroom.orderservice.application.command.UpdateOrderCommand;
 import com.vroomvroom.orderservice.application.dto.OrderDTO;
+import com.vroomvroom.orderservice.presentation.api.OrderControllerDocs;
 import com.vroomvroom.orderservice.presentation.dto.request.CreateOrderReq;
 import com.vroomvroom.orderservice.presentation.dto.request.UpdateOrderReq;
 import com.vroomvroom.orderservice.presentation.dto.response.OrderRes;
@@ -25,7 +26,7 @@ import java.util.UUID;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/orders")
-public class OrderController {
+public class OrderController implements OrderControllerDocs {
 
     private final OrderService orderService;
 
@@ -37,6 +38,7 @@ public class OrderController {
      * @param request 주문 생성 요청
      * @return 생성된 주문 정보
      */
+    @Override
     @PostMapping
     public ResponseEntity<ApiResponse<OrderRes>> createOrder(
             @Valid @RequestBody CreateOrderReq request) {
@@ -72,6 +74,7 @@ public class OrderController {
      * @param orderId 주문 ID
      * @return 주문 정보
      */
+    @Override
     @GetMapping("/{orderId}")
     public ResponseEntity<ApiResponse<OrderRes>> getOrder(@PathVariable UUID orderId) {
         log.info("GET /api/v1/orders/{} - 주문 조회", orderId);
@@ -91,6 +94,7 @@ public class OrderController {
      * @param pageable 페이징 정보 (page, size, sort)
      * @return 주문 목록
      */
+    @Override
     @GetMapping
     public ResponseEntity<ApiResponse<PageResponse<OrderRes>>> getOrders(Pageable pageable) {
         log.info("GET /api/v1/orders - 주문 전체 목록 조회");
@@ -112,6 +116,7 @@ public class OrderController {
      * @param orderId 주문 ID
      * @return OK
      */
+    @Override
     @DeleteMapping("/{orderId}")
     public ResponseEntity<ApiResponse<OrderRes>> cancelOrder(@PathVariable UUID orderId) {
         log.info("DELETE /api/v1/orders/{} - 주문 취소", orderId);
@@ -135,6 +140,7 @@ public class OrderController {
      * @param orderId 주문 ID
      * @return OK
      */
+    @Override
     @PatchMapping("/{orderId}")
     public ResponseEntity<ApiResponse<OrderRes>> updateOrder(
             @PathVariable UUID orderId,

--- a/order-service/src/main/java/com/vroomvroom/orderservice/presentation/OrderController.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/presentation/OrderController.java
@@ -16,6 +16,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -96,7 +99,10 @@ public class OrderController implements OrderControllerDocs {
      */
     @Override
     @GetMapping
-    public ResponseEntity<ApiResponse<PageResponse<OrderRes>>> getOrders(Pageable pageable) {
+    public ResponseEntity<ApiResponse<PageResponse<OrderRes>>> getOrders(
+            @PageableDefault(size = 10, page = 0)
+            @SortDefault(sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable) {
         log.info("GET /api/v1/orders - 주문 전체 목록 조회");
 
         Page<OrderDTO> orderDTOPage = orderService.getOrders(pageable);

--- a/order-service/src/main/java/com/vroomvroom/orderservice/presentation/api/OrderControllerDocs.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/presentation/api/OrderControllerDocs.java
@@ -1,0 +1,97 @@
+package com.vroomvroom.orderservice.presentation.api;
+
+import com.vroomvroom.common.api.PageResponse;
+import com.vroomvroom.orderservice.presentation.dto.request.CreateOrderReq;
+import com.vroomvroom.orderservice.presentation.dto.request.UpdateOrderReq;
+import com.vroomvroom.orderservice.presentation.dto.response.OrderRes;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.UUID;
+
+@Tag(name = "주문 관리", description = "주문 생성, 조회, 수정, 취소 API")
+public interface OrderControllerDocs {
+
+    @Operation(
+            summary = "주문 생성",
+            description = "새로운 주문을 생성합니다. 공급업체, 수령업체, 상품 정보가 필요합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "주문 생성 성공",
+                    content = @Content(schema = @Schema(implementation = OrderRes.class))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 데이터"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "업체 또는 상품을 찾을 수 없음"
+            )
+    })
+    ResponseEntity<com.vroomvroom.common.api.ApiResponse<OrderRes>> createOrder(@Valid @RequestBody CreateOrderReq request);
+
+
+    @Operation(
+            summary = "주문 단건 조회",
+            description = "주문 ID로 특정 주문의 상세 정보를 조회합니다."
+    )
+    @Parameter(
+            name = "orderId",
+            description = "조회할 주문의 ID",
+            required = true
+    )
+    ResponseEntity<com.vroomvroom.common.api.ApiResponse<OrderRes>> getOrder(@PathVariable UUID orderId);
+
+
+    @Operation(
+            summary = "주문 전체 목록 조회",
+            description = "등록된 주문 전체 목록을 페이징하여 조회합니다."
+    )
+    @Parameters({
+            @Parameter(
+                    name = "page",
+                    description = "페이지 번호 (0부터 시작)",
+                    in = ParameterIn.QUERY,
+                    schema = @Schema(type = "integer", defaultValue = "0")
+            ),
+            @Parameter(
+                    name = "size",
+                    description = "페이지 크기",
+                    in = ParameterIn.QUERY,
+                    schema = @Schema(type = "integer", defaultValue = "10")
+            )
+    })
+    ResponseEntity<com.vroomvroom.common.api.ApiResponse<PageResponse<OrderRes>>> getOrders(Pageable pageable);
+
+
+    @Operation(
+            summary = "주문 취소",
+            description = "주문을 취소 처리합니다."
+    )
+    ResponseEntity<com.vroomvroom.common.api.ApiResponse<OrderRes>> cancelOrder(@PathVariable UUID orderId);
+
+
+    @Operation(
+            summary = "주문 수정",
+            description = "기존 주문 정보를 수정합니다."
+    )
+    ResponseEntity<com.vroomvroom.common.api.ApiResponse<OrderRes>> updateOrder(
+            @PathVariable UUID orderId,
+            @Valid @RequestBody UpdateOrderReq request
+    );
+}

--- a/order-service/src/main/java/com/vroomvroom/orderservice/presentation/api/OrderControllerDocs.java
+++ b/order-service/src/main/java/com/vroomvroom/orderservice/presentation/api/OrderControllerDocs.java
@@ -74,6 +74,14 @@ public interface OrderControllerDocs {
                     description = "페이지 크기",
                     in = ParameterIn.QUERY,
                     schema = @Schema(type = "integer", defaultValue = "10")
+            ),
+            @Parameter(
+                    name = "sort",
+                    description = "정렬 조건 (필드명,방향). 예: createdAt,desc",
+                    in = ParameterIn.QUERY,
+                    required = false,  // ✅ 필수 아님
+                    schema = @Schema(type = "string"),
+                    example = "createdAt,desc"
             )
     })
     ResponseEntity<com.vroomvroom.common.api.ApiResponse<PageResponse<OrderRes>>> getOrders(Pageable pageable);

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -14,8 +14,8 @@ spring:
       prod: prod
 
   datasource:
-    url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${ORDER_DB}
-    username: ${POSTGRES_USER}
+    url: jdbc:postgresql://${POSTGRES_HOST:localhost}:${POSTGRES_PORT:5432}/${ORDER_DB:order_db}
+    username: ${POSTGRES_USER:postgres}
     password: ${POSTGRES_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
@@ -32,7 +32,20 @@ spring:
       circuitbreaker:
         enabled: true
 
+  kafka:
+    bootstrap-servers: 9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: all
+      retries: 3
+
 eureka:
   client:
     service-url:
       defaultZone: ${EUREKA_SERVER_URL}
+
+app:
+  kafka:
+    topics:
+      order-created: order.created

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -6,32 +6,28 @@ spring:
   web:
     resources:
       add-mappings: false
-
   profiles:
-    active: local
+    active: ${SPRING_PROFILES_ACTIVE:local}
     group:
       local: local
       prod: prod
-
   datasource:
-    url: jdbc:postgresql://${POSTGRES_HOST:localhost}:${POSTGRES_PORT:5432}/${ORDER_DB:order_db}
+    url: jdbc:postgresql://${POSTGRES_HOST:localhost}:${POSTGRES_PORT:5432}/${POSTGRES_DB:order_db}
     username: ${POSTGRES_USER:postgres}
     password: ${POSTGRES_PASSWORD}
     driver-class-name: org.postgresql.Driver
-
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
     properties:
       hibernate:
-        format_sql: true
-        show_sql: true
-
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: ${SPRING_JPA_FORMAT_SQL:true}
+        show_sql: ${SPRING_JPA_SHOW_SQL:true}
   cloud:
     openfeign:
       circuitbreaker:
         enabled: true
-
   kafka:
     bootstrap-servers: 9092
     producer:
@@ -40,12 +36,22 @@ spring:
       acks: all
       retries: 3
 
+server:
+  port: ${ORDER_SERVER_PORT:19093}
+
 eureka:
   client:
     service-url:
-      defaultZone: ${EUREKA_SERVER_URL}
+      defaultZone: ${EUREKA_SERVER_URL:http://localhost:19090/eureka/}
+    fetch-registry: true
+    register-with-eureka: true
 
 app:
   kafka:
     topics:
       order-created: order.created
+
+logging:
+  level:
+    com.netflix.discovery: ${EUREKA_LOG_LEVEL:OFF}
+    org.springframework.cloud.netflix.eureka: ${EUREKA_LOG_LEVEL:OFF}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #74

## 📌 개요
주문 생성 시 배송 서비스로 이벤트를 발행하는 Kafka 기반 비동기 메시징을 구현했습니다. 트랜잭션 커밋 후 이벤트를 발행하여 데이터 정합성을 보장하고, Swagger를 통한 API 문서화를 추가하여 개발 생산성을 향상시켰습니다.

## 🔁 변경 사항

### Kafka 이벤트 발행 시스템 구축
- **OrderCreatedEvent 도메인 이벤트**
  - 주문 생성 정보를 담는 이벤트 페이로드
  - orderId, 업체/허브 정보, 상품 정보, 수량, 납기일 등 포함
  - 정적 팩토리 메서드 `from()`으로 생성

- **OrderEventPublisher 포트 인터페이스**
  - 도메인 계층의 이벤트 발행 포트
  - `publishOrderCreated(UUID orderId, OrderCreatedEvent event)` 메서드 정의
  - 헥사고날 아키텍처의 아웃바운드 포트 역할

- **KafkaOrderEventHandler 구현체**
  - OrderEventPublisher 인터페이스의 Kafka 구현
  - KafkaTemplate을 사용한 비동기 메시지 발행
  - CompletableFuture로 발행 결과 핸들링
  - 성공 시: partition, offset 로깅
  - 실패 시: 에러 로깅 및 KAFKA_RUNTIME_EXCEPTION 발생

### 트랜잭션 후 이벤트 발행
- **TransactionSynchronizationManager 활용**
  ```java
  TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
      @Override
      public void afterCommit() {
          publishOrderCreatedEvent(savedOrder);
      }
  });
  ```
  - 주문 저장 트랜잭션이 커밋된 후에만 이벤트 발행
  - 트랜잭션 롤백 시 이벤트가 발행되지 않아 데이터 정합성 보장

### 주문 생성 로직 개선
- **재고 확인 로직 추가**
  - HubClient를 통해 허브별 상품 재고 조회
  - 재고 부족 시 `HUB_PRODUCT_OUT_OF_STOCK` 에러 반환

- **공급/수령 업체 검증**
  - 서비스 계층에서도 동일 업체 검증 수행
  - 이중 검증으로 안정성 강화

- **보상 트랜잭션 강화**
  - 주문 저장 실패 시 감소된 재고 자동 원복
  - try-catch로 예외 처리 및 재고 증가 API 호출

### Kafka 설정
- **KafkaProducerConfig**
  - StringSerializer (Key), JsonSerializer (Value)
  - acks=all: 모든 replica 동기화 확인
  - retries=3: 전송 실패 시 3회 재시도
  - OrderCreatedEvent 전용 KafkaTemplate Bean 등록

- **application.yml**
  - bootstrap-servers: 9092
  - topic 이름: order.created (app.kafka.topics.order-created)

### Swagger API 문서화
- **OrderControllerDocs 인터페이스**
  - @Tag: "주문 관리" 그룹화
  - @Operation: 각 API의 요약 및 설명
  - @ApiResponses: 상태 코드별 응답 정의
  - @Parameters: 페이징 파라미터 설명 (page, size, sort)

- **OrderController 개선**
  - OrderControllerDocs 인터페이스 구현
  - @PageableDefault(size=10, page=0): 기본 페이징 값
  - @SortDefault(sort="createdAt", direction=DESC): 기본 정렬 조건

### 의존성 추가
- **common-lib**
  - springdoc-openapi-starter-webmvc-ui:2.3.0

- **order-service**
  - spring-kafka: Kafka Producer 기능
  - springdoc-openapi-starter-webmvc-ui:2.3.0: Swagger UI

### ErrorCode 추가
- `HUB_PRODUCT_OUT_OF_STOCK`: 허브 재고 부족 에러
- `KAFKA_RUNTIME_EXCEPTION`: Kafka 이벤트 발행 실패 에러

### 환경 변수 기본값 설정
- `POSTGRES_HOST`: localhost (기본값)
- `POSTGRES_PORT`: 5432 (기본값)
- `ORDER_DB`: order_db (기본값)
- `POSTGRES_USER`: postgres (기본값)

## 📸 스크린샷
<details>
  <summary>주문 Swagger API 적용</summary>
<img width="2160" height="529" alt="image" src="https://github.com/user-attachments/assets/0c8aaade-24ac-46d9-b3f6-74f618cd143c" />
</details>

## 👀 기타 더 이야기해볼 점


## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.