### PR TITLE
[feat] 업체 및 상품 단건 조회 API 추가

### DIFF
--- a/company-service/src/main/java/com/vroomvroom/company/application/dto/CompanyHubIdResult.java
+++ b/company-service/src/main/java/com/vroomvroom/company/application/dto/CompanyHubIdResult.java
@@ -1,0 +1,9 @@
+package com.vroomvroom.company.application.dto;
+
+import java.util.UUID;
+
+public record CompanyHubIdResult (UUID hubId) {
+    public static CompanyHubIdResult from(UUID hubId) {
+        return new CompanyHubIdResult(hubId);
+    }
+}

--- a/company-service/src/main/java/com/vroomvroom/company/application/dto/ProductOrderInfoResult.java
+++ b/company-service/src/main/java/com/vroomvroom/company/application/dto/ProductOrderInfoResult.java
@@ -1,0 +1,12 @@
+package com.vroomvroom.company.application.dto;
+
+import java.util.UUID;
+
+public record ProductOrderInfoResult (
+        UUID hubId,
+        Long price
+) {
+    public static ProductOrderInfoResult from(UUID hubId, Long price){
+        return new ProductOrderInfoResult(hubId, price);
+    }
+}

--- a/company-service/src/main/java/com/vroomvroom/company/application/service/CompanyService.java
+++ b/company-service/src/main/java/com/vroomvroom/company/application/service/CompanyService.java
@@ -3,6 +3,7 @@ package com.vroomvroom.company.application.service;
 import com.vroomvroom.company.application.command.CreateCompanyCommand;
 import com.vroomvroom.company.application.command.DeleteCommand;
 import com.vroomvroom.company.application.command.UpdateCompanyCommand;
+import com.vroomvroom.company.application.dto.CompanyHubIdResult;
 import com.vroomvroom.company.application.dto.CompanyResult;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,7 +13,8 @@ import java.util.UUID;
 public interface CompanyService {
     CompanyResult createCompany(CreateCompanyCommand command);
     CompanyResult getCompany(UUID companyId);
+    Page<CompanyResult> getCompanyList(String keyword, Pageable pageable);
     CompanyResult updateCompany(UpdateCompanyCommand command);
     void deleteCompany(DeleteCommand command);
-    Page<CompanyResult> getCompanyList(String keyword, Pageable pageable);
+    CompanyHubIdResult getHubIdByCompanyId(UUID companyId);
 }

--- a/company-service/src/main/java/com/vroomvroom/company/application/service/CompanyServiceImpl.java
+++ b/company-service/src/main/java/com/vroomvroom/company/application/service/CompanyServiceImpl.java
@@ -3,6 +3,7 @@ package com.vroomvroom.company.application.service;
 import com.vroomvroom.company.application.command.CreateCompanyCommand;
 import com.vroomvroom.company.application.command.DeleteCommand;
 import com.vroomvroom.company.application.command.UpdateCompanyCommand;
+import com.vroomvroom.company.application.dto.CompanyHubIdResult;
 import com.vroomvroom.company.application.dto.CompanyResult;
 import com.vroomvroom.company.application.validator.AuthorityValidator;
 import com.vroomvroom.company.application.validator.CompanyValidator;
@@ -142,6 +143,20 @@ public class CompanyServiceImpl implements CompanyService {
 
         company.markAsDeleted();
     }
+
+    @Override
+    public CompanyHubIdResult getHubIdByCompanyId(UUID companyId) {
+        log.info("소속 허브 ID 조회 시작");
+
+        Company company = getActiveCompany(companyId);
+        UUID hubId = company.getHubId();
+
+        if (hubId == null) throw new CustomException(ErrorCode.COMPANY_HUB_ID_NOT_FOUND);
+
+        log.info("소속 허브 ID 조회완료");
+        return CompanyHubIdResult.from(hubId);
+    }
+
 
     private Company getActiveCompany(UUID companyId) {
         return companyRepository.findByCompanyIdAndDeletedAtIsNull(companyId)

--- a/company-service/src/main/java/com/vroomvroom/company/application/service/ProductService.java
+++ b/company-service/src/main/java/com/vroomvroom/company/application/service/ProductService.java
@@ -15,6 +15,6 @@ public interface ProductService {
     ProductResult getProduct(UUID productId);
     Page<ProductResult> getProductList(String keyword, Pageable pageable);
     ProductResult updateProduct(UpdateProductCommand command);
-    void deleteCompany(DeleteCommand command);
+    void deleteProduct(DeleteCommand command);
     ProductOrderInfoResult getOrderInfo(UUID productId);
 }

--- a/company-service/src/main/java/com/vroomvroom/company/application/service/ProductService.java
+++ b/company-service/src/main/java/com/vroomvroom/company/application/service/ProductService.java
@@ -3,6 +3,7 @@ package com.vroomvroom.company.application.service;
 import com.vroomvroom.company.application.command.CreateProductCommand;
 import com.vroomvroom.company.application.command.DeleteCommand;
 import com.vroomvroom.company.application.command.UpdateProductCommand;
+import com.vroomvroom.company.application.dto.ProductOrderInfoResult;
 import com.vroomvroom.company.application.dto.ProductResult;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,7 +13,8 @@ import java.util.UUID;
 public interface ProductService {
     ProductResult createProduct(CreateProductCommand command);
     ProductResult getProduct(UUID productId);
+    Page<ProductResult> getProductList(String keyword, Pageable pageable);
     ProductResult updateProduct(UpdateProductCommand command);
     void deleteCompany(DeleteCommand command);
-    Page<ProductResult> getProductList(String keyword, Pageable pageable);
+    ProductOrderInfoResult getOrderInfo(UUID productId);
 }

--- a/company-service/src/main/java/com/vroomvroom/company/application/service/ProductServiceImpl.java
+++ b/company-service/src/main/java/com/vroomvroom/company/application/service/ProductServiceImpl.java
@@ -102,13 +102,13 @@ public class ProductServiceImpl implements ProductService {
                 command.userRole()
         );*/
 
-        companyUpdates(product, command);
+        productUpdates(product, command);
 
         log.info("상품 수정 완료: productId = {}", product.getProductId());
         return ProductResult.from(product);
     }
 
-    public void companyUpdates(Product product, UpdateProductCommand command) {
+    public void productUpdates(Product product, UpdateProductCommand command) {
         if (command.productName() != null) {
             validateDuplicateName(command.productName());
             product.changeProductName(command.productName());
@@ -121,7 +121,7 @@ public class ProductServiceImpl implements ProductService {
 
     @Override
     @Transactional
-    public void deleteCompany(DeleteCommand command) {
+    public void deleteProduct(DeleteCommand command) {
         Product product = getActiveProduct(command.id());
 
         /*        TODO. 유저 권한 체크

--- a/company-service/src/main/java/com/vroomvroom/company/application/service/ProductServiceImpl.java
+++ b/company-service/src/main/java/com/vroomvroom/company/application/service/ProductServiceImpl.java
@@ -3,6 +3,7 @@ package com.vroomvroom.company.application.service;
 import com.vroomvroom.company.application.command.CreateProductCommand;
 import com.vroomvroom.company.application.command.DeleteCommand;
 import com.vroomvroom.company.application.command.UpdateProductCommand;
+import com.vroomvroom.company.application.dto.ProductOrderInfoResult;
 import com.vroomvroom.company.application.dto.ProductResult;
 import com.vroomvroom.company.application.port.HubClient;
 import com.vroomvroom.company.common.exception.CustomException;
@@ -131,6 +132,18 @@ public class ProductServiceImpl implements ProductService {
         );*/
 
         product.markAsDeleted();
+    }
+
+    @Override
+    public ProductOrderInfoResult getOrderInfo(UUID productId) {
+        Product product = getActiveProduct(productId);
+        UUID hubId = product.getHubId();
+        Long price = product.getPrice();
+
+        if (hubId == null) throw new CustomException(ErrorCode.PRODUCT_HUB_ID_NOT_FOUND);
+        if (price == null) throw new CustomException(ErrorCode.PRICE_NOT_FOUND);
+
+        return ProductOrderInfoResult.from(hubId, price);
     }
 
     public void validateDuplicateName(String productName) {

--- a/company-service/src/main/java/com/vroomvroom/company/common/exception/ErrorCode.java
+++ b/company-service/src/main/java/com/vroomvroom/company/common/exception/ErrorCode.java
@@ -30,12 +30,15 @@ public enum ErrorCode {
     DUPLICATE_COMPANY_ADDRESS(HttpStatus.CONFLICT, "이미 존재하는 업체 주소입니다."),
     COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 업체 ID 입니다."),
     COMPANY_DELETED(HttpStatus.BAD_REQUEST, "삭제된 업체입니다."),
+    COMPANY_HUB_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "소속 허브 ID를 찾을 수 없습니다."),
 
     // product
     DUPLICATE_PRODUCT_NAME(HttpStatus.CONFLICT, "이미 존재하는 상품 이름입니다."),
     HUB_MISMATCH(HttpStatus.BAD_REQUEST, "허브 정보가 일치하지 않습니다."),
     INVALID_PRICE(HttpStatus.BAD_REQUEST, "가격은 0보다 큰 값이어야 합니다."),
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 상품 ID 입니다."),
+    PRODUCT_HUB_ID_NOT_FOUND(HttpStatus.BAD_REQUEST, "상품 관리 허브 ID를 찾을 수 없습니다."),
+    PRICE_NOT_FOUND(HttpStatus.BAD_REQUEST, "상품 가격을 찾을 수 없습니다."),
 
 
     // 외부 서비스 검증 실패

--- a/company-service/src/main/java/com/vroomvroom/company/presentation/CompanyController.java
+++ b/company-service/src/main/java/com/vroomvroom/company/presentation/CompanyController.java
@@ -10,6 +10,7 @@ import com.vroomvroom.company.common.api.PageResponse;
 import com.vroomvroom.company.presentation.dto.request.CreateCompanyReq;
 import com.vroomvroom.company.presentation.dto.request.UpdateCompanyReq;
 import com.vroomvroom.company.presentation.dto.response.CompanyDetailRes;
+import com.vroomvroom.company.presentation.dto.response.CompanyHubIdRes;
 import com.vroomvroom.company.presentation.dto.response.CompanyListRes;
 import com.vroomvroom.company.presentation.dto.response.DeleteRes;
 import jakarta.validation.Valid;
@@ -135,4 +136,15 @@ public class CompanyController {
         log.info("업체 삭제 성공: companyId = {}", companyId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
+
+    @GetMapping("/{companyId}/hub")
+    public ResponseEntity<ApiResponse<CompanyHubIdRes>> getHubIdByCompanyId(@PathVariable UUID companyId) {
+        log.info("GET api/v1/companies/{}/hub 소속 허브 ID 반환 요청", companyId);
+
+        CompanyHubIdRes response = CompanyHubIdRes.from(companyService.getHubIdByCompanyId(companyId));
+
+        log.info("소속 허브 ID 반환 성공: companyId = {} hubId = {}", companyId, response.hubId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
 }

--- a/company-service/src/main/java/com/vroomvroom/company/presentation/ProductController.java
+++ b/company-service/src/main/java/com/vroomvroom/company/presentation/ProductController.java
@@ -123,7 +123,7 @@ public class ProductController {
                 // TODO. userId, userRole 추가
         );
 
-        productService.deleteCompany(command);
+        productService.deleteProduct(command);
 
         DeleteRes response = new DeleteRes(
                 productId,

--- a/company-service/src/main/java/com/vroomvroom/company/presentation/ProductController.java
+++ b/company-service/src/main/java/com/vroomvroom/company/presentation/ProductController.java
@@ -12,6 +12,7 @@ import com.vroomvroom.company.presentation.dto.request.UpdateProductReq;
 import com.vroomvroom.company.presentation.dto.response.DeleteRes;
 import com.vroomvroom.company.presentation.dto.response.ProductDetailRes;
 import com.vroomvroom.company.presentation.dto.response.ProductListRes;
+import com.vroomvroom.company.presentation.dto.response.ProductOrderInfoRes;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -130,6 +131,16 @@ public class ProductController {
         );
 
         log.info("상품 삭제 성공: productId = {}", productId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/{productId}/order-info")
+    public ResponseEntity<ApiResponse<ProductOrderInfoRes>> getOrderInfo(@PathVariable UUID productId) {
+        log.info("GET api/v1/products/{}/order-info 주문에 필요한 상품 정보 요청", productId);
+
+        ProductOrderInfoRes response = ProductOrderInfoRes.from(productService.getOrderInfo(productId));
+
+        log.info("주문에 필요한 상품 정보 반환 성공");
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/company-service/src/main/java/com/vroomvroom/company/presentation/dto/response/CompanyHubIdRes.java
+++ b/company-service/src/main/java/com/vroomvroom/company/presentation/dto/response/CompanyHubIdRes.java
@@ -1,0 +1,13 @@
+package com.vroomvroom.company.presentation.dto.response;
+
+import com.vroomvroom.company.application.dto.CompanyHubIdResult;
+
+import java.util.UUID;
+
+public record CompanyHubIdRes (
+        UUID hubId
+) {
+    public static CompanyHubIdRes from(CompanyHubIdResult result) {
+        return new CompanyHubIdRes(result.hubId());
+    }
+}

--- a/company-service/src/main/java/com/vroomvroom/company/presentation/dto/response/ProductOrderInfoRes.java
+++ b/company-service/src/main/java/com/vroomvroom/company/presentation/dto/response/ProductOrderInfoRes.java
@@ -1,0 +1,14 @@
+package com.vroomvroom.company.presentation.dto.response;
+
+import com.vroomvroom.company.application.dto.ProductOrderInfoResult;
+
+import java.util.UUID;
+
+public record ProductOrderInfoRes (
+        UUID hubId,
+        Long price
+) {
+    public static ProductOrderInfoRes from(ProductOrderInfoResult result) {
+        return new ProductOrderInfoRes(result.hubId(), result.price());
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #73 

## 📌 개요
- 다른 서비스에서 업체 ID, 상품 ID로 필요한 정보를 가져오기 위한 조회 전용 API 추가

## 🔁 변경 사항
- 업체 ID로 허브 ID를 반환 API 구현
- 상품 ID로 허브 ID, 가격 정보를 반환 API 구현

## 📸 스크린샷
<img width="744" height="642" alt="image" src="https://github.com/user-attachments/assets/80e362bd-2f3a-45b0-8d68-c05a2d0c0324" />
<img width="744" height="583" alt="image" src="https://github.com/user-attachments/assets/c1dd19ba-690f-4799-b778-c75ca5ce644b" />


## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
